### PR TITLE
Attribute copyright to Scientific Python Developers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 BSD 3-Clause License
 
+Copyright (c) 2024, Scientific Python Developers
 Copyright (c) 2024, Lars Grüter
-Copyright (c) 2024, docstub developers
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Closes #3 because I think all other things are addressed.

Is it okay to grant the additional copyright like I did here and keep the old one? In this case I'd be totally happy to remove the line with my name, but I'd find it a bit strange if we required tools with a longer history that move over to the Scientific Python umbrella to forsake their copyright (I think in some jurisdictions that isn't even possible)? If we require this, the docs definitely need some documentation around this expectation, as I'm myself a bit unclear on what this means, why it's necessary, and its consequences. 

