### PR TITLE
Fix python_requires

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 description = "Generate Python stub files (PYI) from docstrings"
 readme = "README.md"
 license.file = "LICENSE"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 classifiers = [
   "Development Status :: 1 - Planning",
   "Intended Audience :: Developers",


### PR DESCRIPTION
[Path.walk](https://docs.python.org/3/library/pathlib.html#pathlib.Path.walk) was introduced in python 3.12, and it is used in https://github.com/scientific-python/docstub/blob/b8c453f3b070906fc6fd54c567a944a2c9b330c3/src/docstub/_stubs.py#L37, which makes the library only work on python>=3.12