### PR TITLE
draft for pandas examples support

### DIFF
--- a/examples/example_pkg-stubs/_basic.pyi
+++ b/examples/example_pkg-stubs/_basic.pyi
@@ -14,10 +14,19 @@ def func_empty(a1: Any, a2: Any, a3: Any) -> None: ...
 def func_contains(
     self,
     a1: list[float],
-    a2: dict[str, Union[int, str]],
+    a2: sequence[int] | float,
     a3: Sequence[int | float],
     a4: frozenset[bytes],
 ) -> tuple[tuple[int, ...], list[int]]: ...
+def func_contains_dict(
+    self,
+    a1: dict[["str", "int | str"]],
+    a2: dict[str, Union[int, str]],
+    a3: mapping[["int", "str"]],
+) -> dict[["int | str", "float"]]: ...
+def func_literals(
+    self, a1: Literal["A", "B", "C"], a2: Literal[0, "index", 1, "columns", None]
+) -> None: ...
 def func_literals(
     a1: Literal[1, 3, "foo"], a2: Literal["uno", 2, "drei", "four"] = ...
 ) -> None: ...

--- a/examples/example_pkg/_basic.py
+++ b/examples/example_pkg/_basic.py
@@ -32,7 +32,7 @@ def func_contains(self, a1, a2, a3, a4):
     Parameters
     ----------
     a1 : list[float]
-    a2 : dict[str, Union[int, str]]
+    a2 : sequence of int or float
     a3 : Sequence[int | float]
     a4 : frozenset[bytes]
 
@@ -40,6 +40,29 @@ def func_contains(self, a1, a2, a3, a4):
     -------
     r1 : tuple of int
     r2 : list of int
+    """
+
+def func_contains_dict(self, a1, a2, a3):
+    """Dummy.
+
+    Parameters
+    ----------
+    a1 : dict of {str : int or str}
+    a2 : dict[str, Union[int, str]]
+    a3 : mapping of {int : str}
+
+    Returns
+    -------
+    r1 : dict of {int or str : float}
+    """
+
+def func_literals(self, a1, a2):
+    """Dummy.
+
+    Parameters
+    ----------
+    a1 : {"A", "B", "C"}
+    a2 : {0 or "index", 1 or "columns", None}, default None
     """
 
 

--- a/src/docstub/doctype.lark
+++ b/src/docstub/doctype.lark
@@ -1,11 +1,12 @@
 ?start : doctype
 
-doctype : type_or ("," optional)? ("," extra_info)?
+doctype : (literals | type_or) ("," optional)? ("," extra_info)?
 
 type_or : type (("or" | "|") type)*
 
+literals : "{" literal (("," | "or") literal)* "}"
+
 ?type : qualname
-      | "{" literal ("," literal)* "}" -> literals
       | container_of
       | shape_n_dtype
 
@@ -23,7 +24,9 @@ contains: "[" type_or ("," type_or)* "]"
 
 
 // Container-of
-container_of : NAME "of" type_or
+container_of : NAME "of" ( type_or | dict_subtypes )
+
+dict_subtypes : "{" type_or ":" type_or "}"
 
 
 // Array-like form with dtype or shape information


### PR DESCRIPTION
First attempt at grammar extension to support
the examples in
https://pandas.pydata.org/docs/development/contributing_docstring.html#section-3-parameters.

The only one that doesn't parse is the `float, decimal.Decimal or None`, not sure if it
is possible to "look ahead" for an or or to start from the rightmost comma and try to parse
as type, if it works go ahead, otherwise move one comma to the left and try again.

That being said, `dict of {str : int}` parses everything but I it doesn't take into account
that left of the colon are key types right of the colon value types. I have no idea if this
should happen at a grammar level, python processing or both.

Lastly, I did some changes to literals to make sure there can be no confusion between
dict subtypes or literals (colons being inside the curly brackets being the only indicator
seemed like a bad idea). I think this is also a closer match to numpydoc, as from how I understand
the description, `{}` for literals should only be used when only a handful of options are allowed
and therefore is incompatible with type information of any kind.
