### PR TITLE
Point to precise line in parsed source for parsing problems

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ ignore = [
   "ISC001",   # Conflicts with formatter
   "RET504",   # Assignment before `return` statement facilitates debugging
   "PTH123",   # Using builtin open() instead of Path.open() is fine
+  "SIM108",   # Terniary operator is always more readable
 ]
 
 

--- a/src/docstub/_cli.py
+++ b/src/docstub/_cli.py
@@ -124,6 +124,8 @@ def main(source_dir, out_dir, config_path, verbose):
                 stub_content = stub_transformer.python_to_stub(
                     py_content, module_path=source_path
                 )
+            except (SystemExit, KeyboardInterrupt):
+                raise
             except Exception as e:
                 logger.exception("failed creating stub for %s:\n\n%s", source_path, e)
                 continue

--- a/src/docstub/_docstrings.py
+++ b/src/docstub/_docstrings.py
@@ -117,13 +117,12 @@ class Annotation:
 
 
 GrammarErrorFallback = Annotation(
-    value="_GrammarError_",
+    value="Any",
     imports=frozenset(
         (
             KnownImport(
                 import_name="Any",
                 import_path="typing",
-                import_alias="_GrammarError_",
             ),
         )
     ),
@@ -181,7 +180,7 @@ class DoctypeTransformer(lark.visitors.Transformer):
         -------
         annotation : Annotation
             The parsed annotation.
-        unknown_qualnames : set[tuple[str, int, int]]
+        unknown_qualnames : list[tuple[str, int, int]]
             A set containing tuples. Each tuple contains a qualname, its start and its
             end index relative to the given `doctype`.
         """

--- a/src/docstub/_docstrings.py
+++ b/src/docstub/_docstrings.py
@@ -296,7 +296,6 @@ class DoctypeTransformer(lark.visitors.Transformer):
             # Unknown qualname, alias to `Any` and make visible
             self._unknown_qualnames.add((qualname, meta.start_pos, meta.end_pos))
             qualname = escape_qualname(qualname)
-            qualname = f"_UnknownName_{qualname}_"
             any_alias = KnownImport(
                 import_name="Any",
                 import_path="typing",
@@ -314,7 +313,6 @@ class DocstringAnnotations:
 
         if ctx is None:
             ctx = ContextFormatter()
-
         self._ctx: ContextFormatter = ctx
 
     def _doctype_to_annotation(self, doctype, ds_line=0):

--- a/src/docstub/_docstrings.py
+++ b/src/docstub/_docstrings.py
@@ -353,10 +353,10 @@ class DocstringAnnotations:
             return GrammarErrorFallback
 
         else:
-            for _, start_col, stop_col in unknown_qualnames:
+            for name, start_col, stop_col in unknown_qualnames:
                 width = stop_col - start_col
                 details = f"{doctype}\n{' ' * start_col}{'^' * width}\n"
-                ctx.print_message("unknown name in doctype", details=details)
+                ctx.print_message(f"unknown name in doctype: {name!r}", details=details)
             return annotation
 
     @cached_property

--- a/src/docstub/_docstrings.py
+++ b/src/docstub/_docstrings.py
@@ -7,6 +7,7 @@ from functools import cached_property
 from itertools import chain
 from pathlib import Path
 
+import click
 import lark
 import lark.visitors
 from numpydoc.docscrape import NumpyDocString
@@ -343,7 +344,8 @@ class DocstringAnnotations:
             details = None
             if hasattr(error, "get_context"):
                 details = error.get_context(doctype)
-            ctx.print_message("doctype doesn't conform to grammar", details=details)
+                details = details.replace("^", click.style("^", fg="red", bold=True))
+            ctx.print_message("invalid syntax in doctype", details=details)
             return GrammarErrorFallback
 
         except lark.visitors.VisitError as e:
@@ -355,7 +357,8 @@ class DocstringAnnotations:
         else:
             for name, start_col, stop_col in unknown_qualnames:
                 width = stop_col - start_col
-                details = f"{doctype}\n{' ' * start_col}{'^' * width}\n"
+                error_underline = click.style("^" * width, fg="red", bold=True)
+                details = f"{doctype}\n{' ' * start_col}{error_underline}\n"
                 ctx.print_message(f"unknown name in doctype: {name!r}", details=details)
             return annotation
 

--- a/src/docstub/_docstrings.py
+++ b/src/docstub/_docstrings.py
@@ -154,7 +154,7 @@ class DoctypeTransformer(lark.visitors.Transformer):
 
         self.stats = {"grammar_errors": 0}
 
-    def transform(self, doctype):
+    def doctype_to_annotation(self, doctype):
         """Turn a type description in a docstring into a type annotation.
 
         Parameters
@@ -335,7 +335,9 @@ class DocstringAnnotations:
         ctx = self._ctx.with_line(offset=ds_line)
 
         try:
-            annotation, unknown_qualnames = self.transformer.transform(doctype)
+            annotation, unknown_qualnames = self.transformer.doctype_to_annotation(
+                doctype
+            )
 
         except (lark.exceptions.LexError, lark.exceptions.ParseError) as error:
             details = None

--- a/src/docstub/_stubs.py
+++ b/src/docstub/_stubs.py
@@ -9,6 +9,7 @@ import libcst as cst
 import libcst.matchers as cstm
 
 from ._docstrings import DocstringAnnotations, DoctypeTransformer
+from ._utils import ContextFormatter
 
 logger = logging.getLogger(__name__)
 
@@ -616,12 +617,14 @@ class Py2StubTransformer(cst.CSTTransformer):
                 cst.metadata.PositionProvider, docstring_node
             ).start
 
+            ctx = ContextFormatter(
+                path=Path(self.inspector.current_source), line=position.line
+            )
             try:
                 annotations = DocstringAnnotations(
                     docstring_node.evaluated_value,
                     transformer=self.transformer,
-                    source_path=self.inspector.current_source,
-                    source_line=position.line,
+                    ctx=ctx,
                 )
             except Exception as e:
                 logger.exception(

--- a/src/docstub/_stubs.py
+++ b/src/docstub/_stubs.py
@@ -626,6 +626,8 @@ class Py2StubTransformer(cst.CSTTransformer):
                     transformer=self.transformer,
                     ctx=ctx,
                 )
+            except (SystemExit, KeyboardInterrupt):
+                raise
             except Exception as e:
                 logger.exception(
                     "error while parsing docstring of `%s`:\n\n%s",

--- a/src/docstub/_utils.py
+++ b/src/docstub/_utils.py
@@ -1,4 +1,10 @@
+import dataclasses
 import itertools
+import re
+from pathlib import Path
+from textwrap import indent
+
+import click
 
 
 def accumulate_qualname(qualname, *, start_right=False):
@@ -21,3 +27,145 @@ def accumulate_qualname(qualname, *, start_right=False):
         itertools.accumulate(fragments, func=lambda x, y: template.format(x, y))
     )
     return out
+
+
+def escape_qualname(name):
+    """Format a string such that it can be used as a valid Python variable.
+
+    Parameters
+    ----------
+    name : str
+
+    Returns
+    -------
+    qualname : str
+    """
+    qualname = re.sub(r"\W|^(?=\d)", "_", name)
+    return qualname
+
+
+@dataclasses.dataclass(kw_only=True, slots=True, frozen=True)
+class ContextFormatter:
+    """Format messages in context of a location in a file.
+
+    Attributes
+    ----------
+    path :
+        Path to a file for the current context.
+    line :
+        The line in the given file.
+    column :
+        The column in the given line.
+
+    Examples
+    --------
+    >>> from pathlib import Path
+    >>> ctx = ContextFormatter(path=Path("file/with/problems.py"))
+    >>> ctx.format_message("Message")
+    'file/with/problems.py: Message'
+    >>> ctx.with_line(3).format_message("Message with line info")
+    'file/with/problems.py:3: Message with line info'
+    >>> ctx.with_line(3).with_column(2).format_message("Message with column info")
+    'file/with/problems.py:3:2: Message with column info'
+    """
+
+    path: Path = None
+    line: int = None
+    column: int = None
+
+    def with_line(self, line=None, *, offset=0):
+        """Return a new copy with a modified line.
+
+        Parameters
+        ----------
+        line : int, optional
+            The new line.
+        offset : int, optional
+            An offset added to the existing line, or the new one if `line` is provided.
+
+        Returns
+        -------
+        formatter : ContextFormatter
+        """
+        kwargs = dataclasses.asdict(self)
+        if line is None:
+            line = kwargs["line"]
+        if line is None:
+            raise ValueError("can't add offset if the line isn't known")
+        kwargs["line"] = line + offset
+        new = type(self)(**kwargs)
+        return new
+
+    def with_column(self, column=None, *, offset=0):
+        """Return a new copy with a modified column.
+
+        Parameters
+        ----------
+        column : int, optional
+            The new column.
+        offset : int, optional
+            An offset added to the existing column, or the new one if `column` is
+            provided.
+
+        Returns
+        -------
+        formatter : ContextFormatter
+        """
+        kwargs = dataclasses.asdict(self)
+        if column is None:
+            column = kwargs["column"]
+        if column is None:
+            raise ValueError("can't add offset if the column isn't known")
+        kwargs["column"] = column + offset
+        new = type(self)(**kwargs)
+        return new
+
+    def format_message(self, short, *, details=None, ansi_styles=False):
+        """Format a message in context of the saved location.
+
+        Parameters
+        ----------
+        short : str
+            A short summarizing message that shouldn't wrap over multiple lines.
+        details : str, optional
+            An optional multiline message with more details.
+        ansi_styles : bool, optional
+            Whether to format the output with ANSI escape codes.
+
+        Returns
+        -------
+        message : str
+        """
+
+        def style(x, **kwargs):
+            return x
+
+        if ansi_styles:
+            style = click.style
+
+        message = short
+        if self.path:
+            location = style(self.path, bold=True)
+            if self.line:
+                location = f"{location}:{self.line}"
+                if self.column:
+                    location = f"{location}:{self.column}"
+            message = f"{location}: {message}"
+
+        if details:
+            indented = indent(details, prefix="    ", predicate=lambda x: True)
+            message = f"{message}\n{indented}"
+        return message
+
+    def print_message(self, short, *, details=None):
+        """Print a message in context of the saved location.
+
+        Parameters
+        ----------
+        short : str
+            A short summarizing message that shouldn't wrap over multiple lines.
+        details : str, optional
+            An optional multiline message with more details.
+        """
+        msg = self.format_message(short, details=details, ansi_styles=True)
+        click.echo(msg)

--- a/src/docstub/_utils.py
+++ b/src/docstub/_utils.py
@@ -39,8 +39,17 @@ def escape_qualname(name):
     Returns
     -------
     qualname : str
+
+    Examples
+    --------
+    >>> escape_qualname("np.int8")
+    'np_int8'
+    >>> escape_qualname("array-like")
+    'array_like'
+    >>> escape_qualname("# comment (with braces)")
+    '_comment_with_braces_'
     """
-    qualname = re.sub(r"\W|^(?=\d)", "_", name)
+    qualname = re.sub(r"\W+|^(?=\d)", "_", name)
     return qualname
 
 

--- a/src/docstub/_utils.py
+++ b/src/docstub/_utils.py
@@ -81,11 +81,14 @@ class ContextFormatter:
     >>> from pathlib import Path
     >>> ctx = ContextFormatter(path=Path("file/with/problems.py"))
     >>> ctx.format_message("Message")
-    '...problems.py: Message'
+    'file...problems.py: Message'
     >>> ctx.with_line(3).format_message("Message with line info")
-    '...problems.py:3: Message with line info'
-    >>> ctx.with_line(3).with_column(2).format_message("Message with column info")
-    '...problems.py:3:2: Message with column info'
+    'file...problems.py:3: Message with line info'
+    >>> ctx.with_line(3).with_column(2).print_message("Message with column info")
+    file...problems.py:3:2: Message with column info
+    >>> ctx.print_message("Summary", details="More details")
+    file...problems.py: Summary
+        More details
     """
 
     path: Path = None

--- a/src/docstub/_utils.py
+++ b/src/docstub/_utils.py
@@ -10,6 +10,16 @@ import click
 def accumulate_qualname(qualname, *, start_right=False):
     """Return possible partial names from a fully qualified one.
 
+    Parameters
+    ----------
+    qualname : str
+        A fully qualified name, possibliy delimited by ".".
+    start_right : bool, optional
+        By default, dot-delimited names in `qualname` are accumulated by starting with
+        the first name and then appending following names successively. If true instead,
+        the accumulation happens in reverse order: the last name is prepended with
+        previous names successively.
+
     Examples
     --------
     >>> accumulate_qualname("a.b.c")

--- a/src/docstub/_utils.py
+++ b/src/docstub/_utils.py
@@ -81,11 +81,11 @@ class ContextFormatter:
     >>> from pathlib import Path
     >>> ctx = ContextFormatter(path=Path("file/with/problems.py"))
     >>> ctx.format_message("Message")
-    'file/with/problems.py: Message'
+    '...problems.py: Message'
     >>> ctx.with_line(3).format_message("Message with line info")
-    'file/with/problems.py:3: Message with line info'
+    '...problems.py:3: Message with line info'
     >>> ctx.with_line(3).with_column(2).format_message("Message with column info")
-    'file/with/problems.py:3:2: Message with column info'
+    '...problems.py:3:2: Message with column info'
     """
 
     path: Path = None

--- a/src/docstub/doctype.lark
+++ b/src/docstub/doctype.lark
@@ -1,5 +1,6 @@
 ?start : annotation
 
+// ----------------------------------------------------------------------------
 annotation : types_or ("," optional)? ("," extra_info)?
 
 ?types_or : type (("or" | "|") type)*
@@ -18,24 +19,28 @@ extra_info : /[^\r\n]+/
 sphinx_ref : ":" (NAME ":")? NAME ":`" qualname "`"
 
 container: qualname "[" types_or ("," types_or)* ("," PY_ELLIPSES)? "]"
-         | qualname "of" type
+         | qualname "of" type   // TODO allow plural somehow, e.g. "list of int(s)"?
          | qualname "of" "(" types_or ("," types_or)* ("," PY_ELLIPSES)? ")"
          | qualname "of" "{" types_or ":" types_or "}"
 
 // Name with leading dot separated path
 qualname : (/~/ ".")? (NAME ".")* NAME
 
+
+// ----------------------------------------------------------------------------
 // Array-like form with dtype or shape information
-shape_n_dtype : shape? ARRAY_NAME ("of" dtype)?
-              | shape? ARRAY_NAME "of" dtype
-              | shape dtype ARRAY_NAME
-              | dtype ARRAY_NAME
-              | ARRAY_NAME "of shape" shape ("and dtype" dtype)?
-              | ARRAY_NAME "of dtype" dtype ("and shape" shape)?
-ARRAY_NAME : "array"
-           | "ndarray"
-           | "array-like"
-           | "array_like"
+
+shape_n_dtype : shape? array_name ("of" dtype)?
+              | shape? array_name "of" dtype
+              | shape dtype array_name
+              | dtype array_name
+              | array_name "of shape" shape ("and dtype" dtype)?
+              | array_name "of dtype" dtype ("and shape" shape)?
+// Use rule and terminal to capture the array name and its context
+// TODO figure out way not to leak implementation here
+array_name : ARRAY_NAME
+ARRAY_NAME : "array" | "ndarray" | "array-like" | "array_like"
+
 dtype : qualname
 shape : "(" dim ",)"
       | "(" leading_optional? dim (("," dim | insert_optional))* ")"
@@ -47,6 +52,7 @@ insert_optional : "[," dim ("," dim)* "]"
      | NAME
 
 
+// ----------------------------------------------------------------------------
 // Python
 literals : "{" literal ("," literal)* "}"
 
@@ -59,6 +65,8 @@ PY_ELLIPSES : "..."
 
 NAME: /[^\W\d][\w-]*/
 
+
+// ----------------------------------------------------------------------------
 // imports
 %import python (STRING)
 %import common (NEWLINE, NUMBER, LETTER, TEXT, WS)

--- a/tests/test_docstrings.py
+++ b/tests/test_docstrings.py
@@ -3,7 +3,35 @@ from textwrap import dedent
 import pytest
 
 from docstub._analysis import KnownImport
-from docstub._docstrings import DocstringAnnotations, DoctypeTransformer
+from docstub._docstrings import Annotation, DocstringAnnotations, DoctypeTransformer
+
+
+class Test_Annotation:
+    def test_str(self):
+        annotation = Annotation(
+            value="Path",
+            imports=frozenset({KnownImport(import_name="Path", import_path="pathlib")}),
+        )
+        assert str(annotation) == annotation.value
+
+    def test_as_return_tuple(self):
+        path_anno = Annotation(
+            value="Path",
+            imports=frozenset({KnownImport(import_name="Path", import_path="pathlib")}),
+        )
+        sequence_anno = Annotation(
+            value="Sequence",
+            imports=frozenset(
+                {KnownImport(import_name="Sequence", import_path="typing")}
+            ),
+        )
+        return_annotation = Annotation.as_return_tuple([path_anno, sequence_anno])
+        assert return_annotation.value == "tuple[Path, Sequence]"
+        assert return_annotation.imports == path_anno.imports | sequence_anno.imports
+
+    def test_unexpected_value(self):
+        with pytest.raises(ValueError, match="unexpected '~' in annotation value"):
+            Annotation(value="~.foo")
 
 
 class Test_DoctypeTransformer:

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -1,0 +1,74 @@
+from textwrap import dedent
+
+import libcst as cst
+import libcst.matchers as cstm
+
+from docstub._stubs import _get_docstring_node
+
+
+class Test_get_docstring_node:
+
+    def test_func(self):
+        docstring = dedent(
+            '''
+        """First line of docstring.
+
+            Parameters
+            ----------
+            a : int
+                Description of `a`.
+            b : float, optional
+
+            """
+        '''
+        ).strip()
+
+        code = dedent(
+            '''
+        def foo(a, b=None):
+            """First line of docstring.
+
+            Parameters
+            ----------
+            a : int
+                Description of `a`.
+            b : float, optional
+
+            """
+            """Another multiline string
+
+            that  isn't the docstring.
+            """
+            return a + b
+        '''
+        )
+        module = cst.parse_module(code)
+
+        matches = cstm.findall(module, cstm.FunctionDef())
+        assert len(matches) == 1
+        func_def = matches[0]
+
+        docstring_node = _get_docstring_node(func_def)
+
+        assert docstring_node.value == docstring
+
+    def test_func_without_docstring(self):
+        code = '''
+        def foo(a, b=None):
+            c = a + b
+            """Another multiline string
+
+            that  isn't the docstring.
+            """
+            return c
+        '''
+        code = dedent(code)
+        module = cst.parse_module(code)
+
+        matches = cstm.findall(module, cstm.FunctionDef())
+        assert len(matches) == 1
+        func_def = matches[0]
+
+        docstring_node = _get_docstring_node(func_def)
+
+        assert docstring_node is None


### PR DESCRIPTION
When a grammar error occurs or an import for a doctype isn't known, point to the exact line of in the parsed sources.