### PR TITLE
Support attributes and type aliases

### DIFF
--- a/examples/example_pkg-stubs/_basic.pyi
+++ b/examples/example_pkg-stubs/_basic.pyi
@@ -6,7 +6,7 @@ from typing import Any, Literal, Self, Union
 
 from . import CustomException
 
-logger = ...
+logger: Any = ...
 
 __all__ = [
     "func_empty",

--- a/examples/example_pkg-stubs/_basic.pyi
+++ b/examples/example_pkg-stubs/_basic.pyi
@@ -4,9 +4,11 @@ import logging
 from collections.abc import Sequence
 from typing import Any, Literal, Self, Union
 
+from _typeshed import Incomplete
+
 from . import CustomException
 
-logger: Any = ...
+logger: Incomplete
 
 __all__ = [
     "func_empty",

--- a/src/docstub/_analysis.py
+++ b/src/docstub/_analysis.py
@@ -47,13 +47,13 @@ class KnownImport:
 
     Attributes
     ----------
-    import_path : str, optional
+    import_path
         Dotted names after "from".
-    import_name : str, optional
+    import_name
         Dotted names after "import".
-    import_alias : str, optional
+    import_alias
         Name (without ".") after "as".
-    builtin_name : str, optional
+    builtin_name
         Names an object that's builtin and doesn't need an import.
 
     Examples
@@ -69,15 +69,23 @@ class KnownImport:
 
     @classmethod
     @cache
-    def Any(cls):
-        """Create `KnownImport` corresponding to ``from typing import Any``.
+    def typeshed_Incomplete(cls):
+        """Create import corresponding to ``from _typeshed import Incomplete``.
+
+        This type is not actually available at runtime and only intended to be
+        used in stub files [1]_.
 
         Returns
         -------
-        any : Self
+        import : KnownImport
+            The import corresponding to ``from _typeshed import Incomplete``.
+
+        References
+        ----------
+        .. [1] https://typing.readthedocs.io/en/latest/guides/writing_stubs.html#incomplete-stubs
         """
-        out = cls(import_path="typing", import_name="Any")
-        return out
+        import_ = cls(import_path="_typeshed", import_name="Incomplete")
+        return import_
 
     @classmethod
     def one_from_config(cls, name, *, info):

--- a/src/docstub/_analysis.py
+++ b/src/docstub/_analysis.py
@@ -7,6 +7,7 @@ import logging
 import re
 import typing
 from dataclasses import asdict, dataclass
+from functools import cache
 from pathlib import Path
 
 import libcst as cst
@@ -65,6 +66,18 @@ class KnownImport:
     import_path: str = None
     import_alias: str = None
     builtin_name: str = None
+
+    @classmethod
+    @cache
+    def Any(cls):
+        """Create `KnownImport` corresponding to ``from typing import Any``.
+
+        Returns
+        -------
+        any : Self
+        """
+        out = cls(import_path="typing", import_name="Any")
+        return out
 
     @classmethod
     def one_from_config(cls, name, *, info):

--- a/src/docstub/_docstrings.py
+++ b/src/docstub/_docstrings.py
@@ -421,6 +421,28 @@ class DocstringAnnotations:
             return annotation
 
     @cached_property
+    def attributes(self) -> dict[str, Annotation]:
+        annotations = {}
+        for attribute in self.np_docstring["Attributes"]:
+            if not attribute.type:
+                continue
+
+            ds_line = 0
+            for i, line in enumerate(self.docstring.split("\n")):
+                if attribute.name in line and attribute.type in line:
+                    ds_line = i
+                    break
+
+            if attribute.name in annotations:
+                logger.warning("duplicate parameter name %r, ignoring", attribute.name)
+                continue
+
+            annotation = self._doctype_to_annotation(attribute.type, ds_line=ds_line)
+            annotations[attribute.name] = annotation
+
+        return annotations
+
+    @cached_property
     def parameters(self) -> dict[str, Annotation]:
         all_params = chain(
             self.np_docstring["Parameters"], self.np_docstring["Other Parameters"]

--- a/src/docstub/_docstrings.py
+++ b/src/docstub/_docstrings.py
@@ -135,10 +135,7 @@ class Annotation:
         return values, imports
 
 
-GrammarErrorFallback = Annotation(
-    value="Any",
-    imports=frozenset((KnownImport(import_path="typing", import_name="Any"),)),
-)
+GrammarErrorFallback = Annotation(value="Any", imports=frozenset([KnownImport.Any()]))
 
 
 @lark.visitors.v_args(tree=True)

--- a/src/docstub/_docstrings.py
+++ b/src/docstub/_docstrings.py
@@ -135,7 +135,9 @@ class Annotation:
         return values, imports
 
 
-GrammarErrorFallback = Annotation(value="Any", imports=frozenset([KnownImport.Any()]))
+FallbackAnnotation = Annotation(
+    value="Incomplete", imports=frozenset([KnownImport.typeshed_Incomplete()])
+)
 
 
 @lark.visitors.v_args(tree=True)
@@ -396,7 +398,7 @@ class DocstringAnnotations:
                 details = details.replace("^", click.style("^", fg="red", bold=True))
             if ctx:
                 ctx.print_message("invalid syntax in doctype", details=details)
-            return GrammarErrorFallback
+            return FallbackAnnotation
 
         except lark.visitors.VisitError as e:
             tb = "\n".join(traceback.format_exception(e.orig_exc))
@@ -405,7 +407,7 @@ class DocstringAnnotations:
                 ctx.print_message(
                     "unexpected error while parsing doctype", details=details
                 )
-            return GrammarErrorFallback
+            return FallbackAnnotation
 
         else:
             for name, start_col, stop_col in unknown_qualnames:

--- a/src/docstub/_stubs.py
+++ b/src/docstub/_stubs.py
@@ -175,11 +175,15 @@ def _get_docstring_node(node):
 
 
 class Py2StubTransformer(cst.CSTTransformer):
-    """Transform syntax tree of a Python file into the tree of a stub file.
+    """Transform syntax tree of a Python file into the tree of a stub file [1]_.
 
     Attributes
     ----------
     types_db : ~.TypesDatabase
+
+    References
+    ----------
+    .. [1] Stub file specification https://typing.readthedocs.io/en/latest/spec/distributing.html#stub-files
     """
 
     METADATA_DEPENDENCIES = (cst.metadata.PositionProvider,)

--- a/src/docstub/_stubs.py
+++ b/src/docstub/_stubs.py
@@ -199,7 +199,7 @@ class Py2StubTransformer(cst.CSTTransformer):
         leading_whitespace=cst.SimpleWhitespace(value=" "),
         body=[cst.Expr(value=cst.Ellipsis())],
     )
-    _Annotation_Any = cst.Annotation(cst.Name("Any"))
+    _Annotation_Incomplete = cst.Annotation(cst.Name("Incomplete"))
     _Annotation_None = cst.Annotation(cst.Name("None"))
 
     def __init__(self, *, types_db=None, replace_doctypes=None):
@@ -386,10 +386,10 @@ class Py2StubTransformer(cst.CSTTransformer):
                 if pytype.imports:
                     self._required_imports |= pytype.imports
 
-        # Potentially use "Any" except for first param in (class)methods
+        # Potentially use "Incomplete" except for first param in (class)methods
         elif not is_self_or_cls and updated_node.annotation is None:
-            node_changes["annotation"] = self._Annotation_Any
-            import_ = KnownImport(import_path="typing", import_name="Any")
+            node_changes["annotation"] = self._Annotation_Incomplete
+            import_ = KnownImport.typeshed_Incomplete()
             self._required_imports.add(import_)
 
         if node_changes:

--- a/src/docstub/_utils.py
+++ b/src/docstub/_utils.py
@@ -261,3 +261,7 @@ class ContextFormatter:
         if self.path is not None and not isinstance(self.path, Path):
             msg = f"expected `path` to be of type `Path`, got {type(self.path)!r}"
             raise TypeError(msg)
+
+
+class DocstubError(Exception):
+    """An error raised by docstub."""

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -2,6 +2,7 @@ from textwrap import dedent
 
 import libcst as cst
 import libcst.matchers as cstm
+import pytest
 
 from docstub._stubs import Py2StubTransformer, _get_docstring_node
 
@@ -95,3 +96,37 @@ class Test_Py2StubTransformer:
         transformer = Py2StubTransformer()
         result = transformer.python_to_stub(source)
         assert expected in result
+
+    # fmt: off
+    @pytest.mark.parametrize(
+        ("assign", "expected"),
+        [
+            ("annotated: int",                  "annotated: int"),
+            # No implicit optional for values of `None`
+            ("annotated_value: int = None",     "annotated_value: int = ..."),
+            ("undocumented_assign = None",      "undocumented_assign: Any = ..."),
+            # Type aliases are untouched
+            ("annot_alias: TypeAlias = int",    "annot_alias: TypeAlias = int"),
+            ("type type_stmt = int",            "type type_stmt = int"),
+            # Unpacking assignments are expanded
+            ("a, b = (4, 5)",                   "a: Any = ...; b: Any = ..."),
+            ("x, *y = (4, 5)",                  "x: Any = ...; y: Any = ..."),
+            # All is untouched
+            ("__all__ = ['foo']",               "__all__ = ['foo']"),
+            ("__all__: list[str] = ['foo']",    "__all__: list[str] = ['foo']"),
+        ],
+    )
+    @pytest.mark.parametrize("scope", ["module", "class", "nested class"])
+    def test_attributes_no_docstring(self, assign, expected, scope):
+        src = assign
+        if scope == "class":
+            src = f"class TopLevel:\n    {assign}"""
+        if scope == "nested class":
+            src = f"class TopLevel:\n    class Nested:\n        {assign}"""
+
+        transformer = Py2StubTransformer()
+        result = transformer.python_to_stub(src, try_format=False)
+        assert expected in result
+        if "Any" in result:
+            assert "from typing import Any" in result
+    # fmt: on

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -103,14 +103,14 @@ class Test_Py2StubTransformer:
         [
             ("annotated: int",                  "annotated: int"),
             # No implicit optional for values of `None`
-            ("annotated_value: int = None",     "annotated_value: int = ..."),
-            ("undocumented_assign = None",      "undocumented_assign: Any = ..."),
+            ("annotated_value: int = None",     "annotated_value: int"),
+            ("undocumented_assign = None",      "undocumented_assign: Incomplete"),
             # Type aliases are untouched
             ("annot_alias: TypeAlias = int",    "annot_alias: TypeAlias = int"),
             ("type type_stmt = int",            "type type_stmt = int"),
             # Unpacking assignments are expanded
-            ("a, b = (4, 5)",                   "a: Any = ...; b: Any = ..."),
-            ("x, *y = (4, 5)",                  "x: Any = ...; y: Any = ..."),
+            ("a, b = (4, 5)",                   "a: Incomplete; b: Incomplete"),
+            ("x, *y = (4, 5)",                  "x: Incomplete; y: Incomplete"),
             # All is untouched
             ("__all__ = ['foo']",               "__all__ = ['foo']"),
             ("__all__: list[str] = ['foo']",    "__all__: list[str] = ['foo']"),


### PR DESCRIPTION
For now, docstub relies on static analysis only. Therefore, it is very difficult to differentiate a [type alias](https://docs.python.org/3/library/typing.html#type-aliases) such as `x = str` from a regular assignment statement. However, explicit ones are easier to detect and they should be preserved as is (closes https://github.com/scientific-python/docstub/issues/17).

This PR introduces support for several things:

- Collect explicit type aliases during static analysis. Make sure that `x: TypeAlias = str` and `type x = str` are collected as importable type annotations .

- Fallback to `typing.Any` for all un-annotated attributes except in type aliases.

- Replace right side of assignments with `...` except in type aliases.

- Expand assignment statements with multiple targets on the left side, with multiple annotated ones. E.g. `x, y = (3, 4)` to `x: Any = ...; y: Any = ...`.