### PR TITLE
Start writing docs.

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,0 +1,19 @@
+docstub's documentation
+=======================
+
+**Date**: |today|, **Version**: |version|
+
+Welcome! `docstub` is a command-line tool to generate `Python`_ stub files
+(i.e., PYI files) from type descriptions found in `numpydoc`_ style docstrings.
+
+`numpy`_, `scipy`_, and the scikits follow a common convention for docstrings
+that provides for consistency, while also allowing toolchains such as
+`numpydoc`_ to produce well-formatted reference guides.
+
+Our project follows the `SciPy code of conduct`_.
+
+.. _numpy: https://numpy.org
+.. _numpydoc: https://numpydoc.readthedocs.io
+.. _Python: https://www.python.org
+.. _scipy: https://docs.scipy.org
+.. _Scipy code of conduct: https://github.com/scipy/scipy/blob/master/doc/source/dev/conduct/code_of_conduct.rst


### PR DESCRIPTION
Hi @lagru,

Here I'm starting some minimal documentation as per #9.

I'm using the same structure and formats as scikit-image's so we can use the same machinery to build the docs, i.e., generated the rendered HTML pages. I guess we should deploy these somewhere?

I've noticed that

* the scikit-image docs live at https://scikit-image.org/docs/stable/ while
* the NumPy docs live at https://numpy.org/doc/stable/ (no -s).

Maybe it would be more consistent to have `doc/src/index.rst` instead of `doc/source/index.rst`?