### PR TITLE
Use mypy.stubtest in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ env:
   # Many color libraries just need this to be set to any value, but at least
   # one distinguishes color depth, where "3" -> "256-bit color".
   FORCE_COLOR: 3
+  MYPYPATH: ${CI_PROJECT_DIR}/stubs
 
 jobs:
   lint:
@@ -69,4 +70,8 @@ jobs:
 
       - name: Generate docstub stubs
         run: |
-          python -m docstub -v src/docstub
+          python -m docstub -v src/docstub -o ${MYPYPATH}/docstub
+
+      - name: Check docstub stubs with mypy
+        run: |
+          python -m mypy.stubtest docstub

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dev = [
 test = [
   "pytest >=5.0.0",
   "pytest-cov >= 5.0.0",
+  "mypy",
 ]
 
 [project.urls]
@@ -80,6 +81,7 @@ extend-select = [
   "UP",       # pyupgrade
   "YTT",      # flake8-2020
   "EXE",      # flake8-executable
+#  "PYI",      # flake8-pyi
 ]
 ignore = [
   "PLR09",    # Too many <...>

--- a/src/docstub/_cli.py
+++ b/src/docstub/_cli.py
@@ -14,7 +14,12 @@ from ._analysis import (
 )
 from ._cache import FileCache
 from ._config import Config
-from ._stubs import Py2StubTransformer, walk_source, walk_source_and_targets
+from ._stubs import (
+    Py2StubTransformer,
+    try_format_stub,
+    walk_source,
+    walk_source_and_targets,
+)
 from ._version import __version__
 
 logger = logging.getLogger(__name__)
@@ -171,6 +176,7 @@ def main(source_dir, out_dir, config_path, verbose):
                 stub_content = stub_transformer.python_to_stub(
                     py_content, module_path=source_path
                 )
+                stub_content = try_format_stub(stub_content)
             except (SystemExit, KeyboardInterrupt):
                 raise
             except Exception as e:

--- a/src/docstub/_stubs.py
+++ b/src/docstub/_stubs.py
@@ -264,7 +264,7 @@ class Py2StubTransformer(cst.CSTTransformer):
         if self.types_db is not None:
             self.types_db.current_source = value
 
-    def python_to_stub(self, source, *, module_path=None, try_format=True):
+    def python_to_stub(self, source, *, module_path=None):
         """Convert Python source code to stub-file ready code.
 
         Parameters
@@ -274,9 +274,6 @@ class Py2StubTransformer(cst.CSTTransformer):
             The location of the source that is transformed into a stub file.
             If given, used to enhance logging & error messages with more
             context information.
-        try_format : bool, optional
-            Try to format the output, if the appropriate dependencies are
-            installed.
 
         Returns
         -------
@@ -292,8 +289,6 @@ class Py2StubTransformer(cst.CSTTransformer):
             source_tree = cst.metadata.MetadataWrapper(source_tree)
             stub_tree = source_tree.visit(self)
             stub = stub_tree.code
-            if try_format is True:
-                stub = try_format_stub(stub)
             return stub
         finally:
             self._scope_stack = None

--- a/src/docstub/_stubs.py
+++ b/src/docstub/_stubs.py
@@ -448,7 +448,9 @@ class Py2StubTransformer(cst.CSTTransformer):
         return cst.RemovalSentinel.REMOVE
 
     def leave_Comment(self, original_node, updated_node):
-        """Drop comment from stub file.
+        """Drop comments from stub file.
+
+        Special typing or formatting related comments are preserved.
 
         Parameters
         ----------
@@ -459,7 +461,10 @@ class Py2StubTransformer(cst.CSTTransformer):
         -------
         cst.RemovalSentinel
         """
-        return cst.RemovalSentinel.REMOVE
+        comment = original_node.value
+        if comment.startswith("# type:"):
+            return cst.RemovalSentinel.REMOVE
+        return updated_node
 
     @_log_error_with_line_context
     def leave_Assign(self, original_node, updated_node):

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -173,7 +173,7 @@ class Test_Py2StubTransformer:
             src = NESTED_CLASS_ATTRIBUTE_TEMPLATE.format(assign=assign, doctype="")
 
         transformer = Py2StubTransformer()
-        result = transformer.python_to_stub(src, try_format=False)
+        result = transformer.python_to_stub(src)
 
         # Find exactly one occurrence of `expected`
         pattern = f"^ *({re.escape(expected)})$"
@@ -212,7 +212,7 @@ class Test_Py2StubTransformer:
             src = NESTED_CLASS_ATTRIBUTE_TEMPLATE.format(assign=assign, doctype=doctype)
 
         transformer = Py2StubTransformer()
-        result = transformer.python_to_stub(src, try_format=False)
+        result = transformer.python_to_stub(src)
 
         # Find exactly one occurrence of `expected`
         pattern = f"^ *({re.escape(expected)})$"

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -225,3 +225,53 @@ class Test_Py2StubTransformer:
         if "Incomplete" in result:
             assert "from _typeshed import Incomplete" in result
     # fmt: on
+
+    def test_undocumented_objects(self):
+        # TODO test undocumented objects
+        #  https://typing.readthedocs.io/en/latest/guides/writing_stubs.html#undocumented-objects
+        pass
+
+    def test_preserved_type_comment(self):
+        source = dedent(
+            """
+            # Import untyped library
+            import untyped  # type: ignore
+            """
+        )
+        expected = dedent(
+            """
+            import untyped  # type: ignore
+            """
+        )
+        transformer = Py2StubTransformer()
+        result = transformer.python_to_stub(source)
+        assert expected == result
+
+    @pytest.mark.xfail(reason="not supported yet")
+    def test_preserved_comments_extended(self):
+        source = dedent(
+            """
+            # Import untyped library
+            import untyped  # type: ignore
+
+            class Foo:
+                a = 3  # type: int
+
+            def bar(x: str) -> None:  # undocumented
+              pass
+            """
+        )
+        expected = dedent(
+            """
+            import untyped  # type: ignore
+
+            class Foo:
+                a = 3  # type: int
+
+            def bar(x: str) -> None: ...  # undocumented
+            """
+        )
+
+        transformer = Py2StubTransformer()
+        result = transformer.python_to_stub(source)
+        assert expected == result


### PR DESCRIPTION
The goal here is to run docstub on its own codebase and check the resulting stubs with mypy. So far it's been a good way to highlight a few missing features.