### PR TITLE
Add direct support for dataclasses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Project specific folders
+stubs/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/src/docstub/_stubs.py
+++ b/src/docstub/_stubs.py
@@ -119,6 +119,7 @@ class ScopeType(enum.StrEnum):
     # docstub: on
 
 
+# TODO use `libcst.metadata.ScopeProvider` instead
 @dataclass(slots=True, frozen=True)
 class _Scope:
     """"""

--- a/stubtest_allow.txt
+++ b/stubtest_allow.txt
@@ -2,6 +2,3 @@ docstub\._version\..*
 docstub\..*\.__match_args__$
 docstub._cache.FuncSerializer.__type_params__
 docstub._cli.main
-docstub._config.Config.__init__
-docstub._docstrings.Annotation.__init__
-docstub._stubs._Scope.__init__

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -394,3 +394,35 @@ class Test_Py2StubTransformer:
         # remove these empty lines from the result too
         result = dedent(result)
         assert expected == result
+
+    @pytest.mark.parametrize("decorator", ["dataclass", "dataclasses.dataclass"])
+    def test_dataclass(self, decorator):
+        source = dedent(
+            f"""
+            @{decorator}
+            class Foo:
+                a: float
+                b: int = 3
+                c: str = None
+                d: dict[str, Any] = field(default_factory=dict)
+                e: ClassVar
+                f: ClassVar[float]
+                g: Final[ClassVar[int]] = 1
+            """
+        )
+        expected = dedent(
+            f"""
+            @{decorator}
+            class Foo:
+                a: float
+                b: int = ...
+                c: str = ...
+                d: dict[str, Any] = ...
+                e: ClassVar
+                f: ClassVar[float]
+                g: Final[ClassVar[int]]
+            """
+        )
+        transformer = Py2StubTransformer()
+        result = transformer.python_to_stub(source)
+        assert expected == result

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -404,10 +404,12 @@ class Test_Py2StubTransformer:
                 a: float
                 b: int = 3
                 c: str = None
+                _: KW_ONLY
                 d: dict[str, Any] = field(default_factory=dict)
-                e: ClassVar
-                f: ClassVar[float]
-                g: Final[ClassVar[int]] = 1
+                e: InitVar[tuple] = tuple()
+                f: ClassVar
+                g: ClassVar[float]
+                h: Final[ClassVar[int]] = 1
             """
         )
         expected = dedent(
@@ -417,10 +419,12 @@ class Test_Py2StubTransformer:
                 a: float
                 b: int = ...
                 c: str = ...
+                _: KW_ONLY
                 d: dict[str, Any] = ...
-                e: ClassVar
-                f: ClassVar[float]
-                g: Final[ClassVar[int]]
+                e: InitVar[tuple] = ...
+                f: ClassVar
+                g: ClassVar[float]
+                h: Final[ClassVar[int]]
             """
         )
         transformer = Py2StubTransformer()


### PR DESCRIPTION
Dataclasses require special treatment compared to normal classes when typed with a stub file. Unlike with attributes of normal classes we want to preserve whether there is a default value. So
```python
# file.py

from dataclasses import dataclass, field, KW_ONLY, InitVar
from typing import ClassVar, Final

class Foo:
    a: float
    b: int = 3
    c: str = None
    _: KW_ONLY
    d: dict[str, Any] = field(default_factory=dict)
    e: InitVar[tuple] = tuple()
    f: ClassVar
    g: ClassVar[float]
    h: Final[ClassVar[int]] = 1
```
should become
```python
# file.pyi

from dataclasses import dataclass, field, KW_ONLY, InitVar
from typing import ClassVar, Final, 

class Foo:
    a: float
    b: int = ...
    c: str = ...
    _: KW_ONLY
    d: dict[str, Any] = ...
    e: InitVar[tuple] = ...
    f: ClassVar
    g: ClassVar[float]
    h: Final[ClassVar[int]]
```
Note the class variable `g` that is still treated like a normal attribute – its value is stripped.
