### PR TITLE
Check test suite with mypy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,10 +73,14 @@ jobs:
           python -m docstub -v --config=examples/docstub.toml examples/example_pkg
           git diff --exit-code examples/ && echo "Stubs for example_pkg did not change"
 
-      - name: Generate docstub stubs
+      - name: Generate stubs for docstub
         run: |
           python -m docstub -v src/docstub -o ${MYPYPATH}/docstub
 
-      - name: Check docstub stubs with mypy
+      - name: Check with mypy.stubtest
         run: |
           python -m mypy.stubtest --allowlist stubtest_allow.txt docstub
+
+      - name: Check tests/ with mypy
+        run: |
+          python -m mypy tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,3 +108,7 @@ run.source = ["docstub"]
 cst = {import = "libcst", as="cst"}
 lark = {import = "lark"}
 numpydoc = {import = "numpydoc"}
+
+
+[tool.mypy]
+strict = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,3 +112,16 @@ numpydoc = {import = "numpydoc"}
 
 [tool.mypy]
 strict = true
+disable_error_code = ["type-arg"]
+
+# Don't type test suite itself but check if usage makes sense with docstub's stubs
+[[tool.mypy.overrides]]
+module = "tests.*"
+check_untyped_defs = true
+allow_untyped_defs = true
+disable_error_code = ["var-annotated", "union-attr"]
+
+# NumPyDoc isn't typed?
+[[tool.mypy.overrides]]
+module = ["numpydoc.*"]
+ignore_missing_imports = true

--- a/src/docstub/_analysis.py
+++ b/src/docstub/_analysis.py
@@ -209,8 +209,17 @@ class KnownImport:
         return out
 
 
-def _is_type(value) -> bool:
-    """Check if value is a type."""
+def _is_type(value):
+    """Check if value is a type.
+
+    Parameters
+    ----------
+    value : Any
+
+    Returns
+    -------
+    is_type : bool
+    """
     # Checking for isinstance(..., type) isn't enough, some types such as
     # typing.Literal don't pass that check. So combine with checking for a
     # __class__ attribute. Not sure about edge cases!
@@ -410,7 +419,7 @@ class TypesDatabase:
     ----------
     current_source : Path | None
     source_pkgs : list[Path]
-    known_imports: dict[str, KnownImport]
+    known_imports : dict[str, KnownImport]
     stats : dict[str, Any]
 
     Examples
@@ -430,8 +439,8 @@ class TypesDatabase:
         """
         Parameters
         ----------
-        source_pkgs: list[Path], optional
-        known_imports: dict[str, KnownImport], optional
+        source_pkgs : list[Path], optional
+        known_imports : dict[str, KnownImport], optional
             If not provided, defaults to imports returned by
             :func:`common_known_imports`.
         """

--- a/src/docstub/_cache.py
+++ b/src/docstub/_cache.py
@@ -1,6 +1,6 @@
 import logging
 from functools import cached_property
-from typing import Protocol
+from typing import Any, Protocol
 
 logger = logging.getLogger(__name__)
 
@@ -74,7 +74,7 @@ class FuncSerializer[T](Protocol):
 
     suffix: str
 
-    def hash_args(self, *args, **kwargs) -> str:
+    def hash_args(self, *args: Any, **kwargs: Any) -> str:
         """Compute a unique hash from the arguments passed to a function."""
 
     def serialize(self, data: T) -> bytes:
@@ -85,7 +85,7 @@ class FuncSerializer[T](Protocol):
 
 
 class FileCache:
-    """Cache results from a function call as a files on disk.
+    """Cache results from a function call as a file on disk.
 
     This class can cache results of a function to the disk. A unique key is
     generated from the arguments to the function, and the result is cached
@@ -100,7 +100,7 @@ class FileCache:
             The function whose output shall be cached.
         serializer : FuncSerializer
             An interface that matches the given `func`. It must implement the
-            `FileCachIO` protocol.
+            `FuncSerializer` protocol.
         cache_dir : Path
             The directory of the cache.
         name : str
@@ -126,7 +126,17 @@ class FileCache:
         return _named_cache_dir
 
     def __call__(self, *args, **kwargs):
-        """Call the wrapped `func` and cache each result in a file."""
+        """Call the wrapped `func` and cache each result in a file.
+
+        Parameters
+        ----------
+        args : Any
+        kwargs : Any
+
+        Returns
+        -------
+        data : Any
+        """
         key = self.serializer.hash_args(*args, **kwargs)
         entry_path = self.named_cache_dir / f"{key}{self.serializer.suffix}"
         if entry_path.is_file():

--- a/src/docstub/_stubs.py
+++ b/src/docstub/_stubs.py
@@ -395,7 +395,7 @@ class Py2StubTransformer(cst.CSTTransformer):
 
         Parameters
         ----------
-        source  : str
+        source : str
         module_path : Path, optional
             The location of the source that is transformed into a stub file.
             If given, used to enhance logging & error messages with more
@@ -573,6 +573,7 @@ class Py2StubTransformer(cst.CSTTransformer):
         name = original_node.name.value
         pytypes = self._pytypes_stack[-1]
         if not pytypes and scope.is_class_init:
+            # Fallback to class if __init__'s docstring doesn't document parameters
             pytypes = self._pytypes_stack[-2]
 
         if pytypes:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+# Include this file, so mypy recognizes `tests` as a module and allows
+# module specific overrides, otherwise they don't seem to work

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -43,13 +43,13 @@ class Test_FileCache:
         class Serializer:
             suffix = ".txt"
 
-            def hash_args(self, arg):
+            def hash_args(self, arg: int) -> str:
                 return str(hash(arg))
 
-            def serialize(self, data):
+            def serialize(self, data: int) -> bytes:
                 return str(data).encode()
 
-            def deserialize(self, raw):
+            def deserialize(self, raw: bytes) -> int:
                 return int(raw.decode())
 
         counter = defaultdict(lambda: 0)

--- a/tests/test_docstrings.py
+++ b/tests/test_docstrings.py
@@ -122,7 +122,7 @@ class Test_DoctypeTransformer:
     @pytest.mark.parametrize("shape", ["(2, 3)", "(N, m)", "3D", "2-D", "(N, ...)"])
     def test_shape_n_dtype(self, fmt, expected_fmt, name, dtype, shape):
 
-        def escape(name):
+        def escape(name: str) -> str:
             return name.replace("-", "_").replace(".", "_")
 
         doctype = fmt.format(name=name, dtype=dtype, shape=shape)

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -49,6 +49,7 @@ class Test_get_docstring_node:
         assert len(matches) == 1
         func_def = matches[0]
 
+        assert isinstance(func_def, cst.FunctionDef)
         docstring_node = _get_docstring_node(func_def)
 
         assert docstring_node.value == docstring
@@ -70,6 +71,7 @@ class Test_get_docstring_node:
         assert len(matches) == 1
         func_def = matches[0]
 
+        assert isinstance(func_def, cst.FunctionDef)
         docstring_node = _get_docstring_node(func_def)
 
         assert docstring_node is None


### PR DESCRIPTION
After generating the stubs for docstub, run mypy on our own test suite. This highlighted a few places that still needed cleanup and prompted b82b6f15b976151e9a3a0dd6e872aaf3fb8cd048 and 0430238880964d81eee929c433e18afd1a56560e.

Right now this looks close to perfect for the setup I'm planning for scikit-image: use existing type descriptions in docstrings, and validate the correctly typed API by running mypy on the test suite of scikit-image.