### PR TITLE
Update import for Generator and Callable types

### DIFF
--- a/src/docstub/_docstrings.py
+++ b/src/docstub/_docstrings.py
@@ -114,7 +114,7 @@ class Annotation:
             value = f"{value}, {return_annotation.value}"
 
         value = f"Generator[{value}]"
-        imports |= {KnownImport(import_path="typing", import_name="Generator")}
+        imports |= {KnownImport(import_path="collections.abc", import_name="Generator")}
         generator = cls(value=value, imports=imports)
         return generator
 

--- a/src/docstub/default_config.toml
+++ b/src/docstub/default_config.toml
@@ -18,7 +18,7 @@ extend_grammar = """
 #         defaults to "false"
 [tool.docstub.known_imports]
 Path = { from = "pathlib" }
-Callable = { from = "typing" }
+Callable = { from = "collections.abc" }
 np = { import = "numpy", as = "np" }
 NDArray = { from = "numpy.typing" }
 ArrayLike = { from = "numpy.typing" }

--- a/tests/test_docstrings.py
+++ b/tests/test_docstrings.py
@@ -22,7 +22,7 @@ class Test_Annotation:
         sequence_anno = Annotation(
             value="Sequence",
             imports=frozenset(
-                {KnownImport(import_name="Sequence", import_path="typing")}
+                {KnownImport(import_name="Sequence", import_path="collections.abc")}
             ),
         )
         return_annotation = Annotation.many_as_tuple([path_anno, sequence_anno])
@@ -244,7 +244,7 @@ class Test_DocstringAnnotations:
         annotations = DocstringAnnotations(docstring, transformer=transformer)
         assert annotations.returns.value == "Generator[tuple[int, str]]"
         assert annotations.returns.imports == {
-            KnownImport(import_path="typing", import_name="Generator")
+            KnownImport(import_path="collections.abc", import_name="Generator")
         }
 
     def test_receives(self, caplog):
@@ -268,7 +268,7 @@ class Test_DocstringAnnotations:
             == "Generator[tuple[int, str], tuple[float, bytes]]"
         )
         assert annotations.returns.imports == {
-            KnownImport(import_path="typing", import_name="Generator")
+            KnownImport(import_path="collections.abc", import_name="Generator")
         }
 
     def test_full_generator(self, caplog):
@@ -295,7 +295,7 @@ class Test_DocstringAnnotations:
             "Generator[tuple[int, str], tuple[float, bytes], bool]"
         )
         assert annotations.returns.imports == {
-            KnownImport(import_path="typing", import_name="Generator")
+            KnownImport(import_path="collections.abc", import_name="Generator")
         }
 
     def test_yields_and_returns(self, caplog):
@@ -315,7 +315,7 @@ class Test_DocstringAnnotations:
         annotations = DocstringAnnotations(docstring, transformer=transformer)
         assert annotations.returns.value == ("Generator[tuple[int, str], None, bool]")
         assert annotations.returns.imports == {
-            KnownImport(import_path="typing", import_name="Generator")
+            KnownImport(import_path="collections.abc", import_name="Generator")
         }
 
     def test_duplicate_parameters(self, caplog):


### PR DESCRIPTION
Several of these types have been deprecated from typing to the ones in collections.abc.
If you want to leave this open a bit I can add more if there were as I notice them while I try the
library, otherwise I can do other PRs, whatever makes your life easier.
