### PR TITLE
Fix grammar and allow plural "(s)"

### DIFF
--- a/src/docstub/doctype.lark
+++ b/src/docstub/doctype.lark
@@ -1,6 +1,9 @@
 // Grammar defining the syntax for docstring type descriptions
 //
 // Reading and introduction order of rules starts at the top of the tree.
+//
+// Reference for Lark grammars:
+// https://lark-parser.readthedocs.io/en/latest/grammar.html
 
 
 ?start: annotation_with_meta
@@ -12,7 +15,8 @@
 ?annotation_with_meta: type ("," optional)? ("," extra_info)?
 
 
-// Just the docstring type annotation without meta information.
+// A type annotation. Can range from a simple qualified name to a complex
+// nested construct of types.
 ?type: qualname
     | union
     | subscription
@@ -35,28 +39,41 @@ qualname: (/~/ ".")? (NAME ".")* NAME
 union: type (_OR type)+
 
 
+// Operator used in unions.
+_OR: "or" | "|"
+
+
 // An expression where an object is subscribed with "A[v, ...]".
 subscription: qualname "[" type ("," type)* ("," ELLIPSES)? "]"
 
 
-// A natural language version that combines one or multiple literals inside
+// Allow Python's ellipses object
+ELLIPSES: "..."
+
+
+// A natural language expression that combines one or multiple literals inside
 // curly braces `{l1, l2, ...}`
 natlang_literal: "{" literal_item ("," literal_item)* "}"
 
 
 // An single item in a literal expression (or `optional`). We must also allow
-// for qualified names, since a "class" can be used as a literal too.
+// for qualified names, since a "class" or enum can be used as a literal too.
 ?literal_item: ELLIPSES | STRING | NUMBER | qualname
 
 
-// A natural language form of the subscription expression for containers.
-// This variant explicitly doesn't allow nesting more complex types inside it
-// to maintain readability. However, unions with with simple qualnames are
-// allowed, e.g, `list of (int or float)`.
-natlang_container: qualname "of" qualname "(s)"?
+// Natural language forms of the subscription expression for containers.
+// These forms allow nesting allow nesting in and with other expressions. But
+// it's discouraged to do so extensively to maintain readability.
+natlang_container: qualname "of" qualname _PLURAL_S?
     | qualname "of" "(" union ")"
     | _natlang_tuple
     | _natlang_mapping
+
+
+// Indicate the plural version of a qualname by appending "(s)".
+// The negative lookbehind in this regex disallows whitespace directly in front
+// of this.
+_PLURAL_S: /(?<!\s)\(s\)/
 
 
 // Special behavior for tuples [1].
@@ -69,7 +86,7 @@ _natlang_tuple: qualname "of" "(" type "," ELLIPSES ")"
 _natlang_mapping: qualname "of" "{" type ":" (type | union) "}"
 
 
-// A natural language alternative to describe arrays with a dtype and shape
+// A natural language alternative to describe arrays with a dtype and shape.
 natlang_array: array_name "of dtype" dtype ("and shape" shape)?
     | array_name "of shape" shape ("and dtype" dtype)?
     | shape array_name ("of" dtype)?
@@ -87,8 +104,10 @@ natlang_array: array_name "of dtype" dtype ("and shape" shape)?
 array_name: ARRAY_NAME
 ARRAY_NAME: "array" | "ndarray" | "array-like" | "array_like"
 
+
 // The dtype used in an array expression.
 ?dtype: qualname | "(" union ")"
+
 
 // The shape used in an array expression. Possibly to liberal right now in
 // what it allows. Since there is currently no support to type the shape of
@@ -97,13 +116,16 @@ shape: "(" dim ",)"
     | "(" leading_optional_dim? dim (("," dim | insert_optional_dim))* ")"
     | NUMBER "-"? "D"
 
+
 // Optional dimensions in a `shape` expression placed at the start,
 // e.g., `([3 ,] N)`.
 ?leading_optional_dim: "[" dim ("," dim)* ",]"
 
+
 // Optional dimensions in a `shape` expression placed anywhere but the start,
 // e.g., `(A[, B], C[, D])`.
 ?insert_optional_dim: "[," dim ("," dim)* "]"
+
 
 // Dimension can be a number, ellipses ('...') or a simple name. A simple name
 // can be bound to a specific number, e.g. `N=3`.
@@ -119,20 +141,12 @@ optional:  "optional" | "default" ("=" | ":")? literal_item
 // Currently dropped during transformation.
 extra_info: /[^\r\n]+/
 
-
-// Operator used in unions.
-_OR: "or" | "|"
-
-
-// Allow Python's ellipses object
-ELLIPSES: "..."
-
 // A simple name. Can start with a number or character. Can be delimited by "_"
 // or "-" but not by ".".
 NAME: /[^\W\d][\w-]*/
 
 
 %import python (STRING)
-%import common (NEWLINE, NUMBER, LETTER, TEXT, WS)
+%import common (NUMBER, WS_INLINE)
 
-%ignore WS
+%ignore WS_INLINE

--- a/src/docstub/doctype.lark
+++ b/src/docstub/doctype.lark
@@ -13,8 +13,7 @@ annotation_with_meta : type ("," optional)? ("," extra_info)?
 
 
 // Just the docstring type annotation without meta information.
-?type :
-    | qualname
+?type: qualname
     | rst_role
     | literal_expression
     | subscription_expression
@@ -37,8 +36,7 @@ or_expression : type (("or" | "|") type)+
 
 // An expression where an object is subscribed with "A[v, ...]". We extend this
 // syntax with a natural language variant `A of (v, ...)` and `A of {k : v}`.
-subscription_expression:
-    | qualname "[" type ("," type)* ("," ELLIPSES)? "]"
+subscription_expression: qualname "[" type ("," type)* ("," ELLIPSES)? "]"
     | qualname "of" type   // TODO allow plural somehow, e.g. "list of int(s)"?
     | qualname "of" "(" type ("," type)* ("," ELLIPSES)? ")"
     | qualname "of" "{" type ":" type "}"
@@ -50,16 +48,14 @@ literal_expression : "{" literal_item ("," literal_item)* "}"
 
 // An single item in a literal expression (or `optional`). We must also allow
 // for qualified names, since a "class" can be used as a literal too.
-?literal_item :
-    | ELLIPSES
+?literal_item: ELLIPSES
     | STRING
     | NUMBER
     | qualname  // TODO should rst_role too? make combined `type qualname | rst_role`?
 
 
 // A natural language alternative to describe arrays with a dtype and shape
-array_expression :
-    | array_name "of dtype" dtype ("and shape" shape)?
+array_expression: array_name "of dtype" dtype ("and shape" shape)?
     | array_name "of shape" shape ("and dtype" dtype)?
     | shape array_name ("of" dtype)?
     | shape? array_name "of" dtype
@@ -80,8 +76,7 @@ ARRAY_NAME : "array" | "ndarray" | "array-like" | "array_like"
 // The shape used in an array expression. Possibly to liberal right now in
 // what it allows. Since there is currently no support to type the shape of
 // NumPy arrays, this information is dropped during the transformation.
-shape :
-    | "(" dim ",)"
+shape: "(" dim ",)"
     | "(" leading_optional_dim? dim (("," dim | insert_optional_dim))* ")"
     | NUMBER "-"? "D"
 

--- a/src/docstub/doctype.lark
+++ b/src/docstub/doctype.lark
@@ -9,69 +9,86 @@
 // The basic structure of a full docstring annotation as it comes after the
 // `name : `. It includes additional meta information that is optional and
 // currently ignored.
-annotation_with_meta: type ("," optional)? ("," extra_info)?
+?annotation_with_meta: type ("," optional)? ("," extra_info)?
 
 
 // Just the docstring type annotation without meta information.
 ?type: qualname
-    | rst_role
-    | literal_expression
-    | subscription_expression
-    | array_expression
-    | or_expression
+    | union
+    | subscription
+    | natlang_literal
+    | natlang_container
+    | natlang_array
 
 
-// Name with leading dot separated path
+// A qualified name which can contain multiple parts separated by a ".".
+// Optionally, "~." can be prefixed to abbreviate a leading part of the name.
+// Optionally, a qualname can be wrapped in the style of a reStructuredText
+// role [1], e.g, as used by Sphinx.
+// [1] https://docutils.sourceforge.io/docs/ref/rst/roles.html
+//
 qualname: (/~/ ".")? (NAME ".")* NAME
+    | (":" (NAME ":")? NAME ":")? "`" qualname "`" -> rst_role
 
 
-// A qualname can be wrapped in a reStructuredText role, e.g, as used by Sphinx.
-// https://docutils.sourceforge.io/docs/ref/rst/roles.html
-rst_role: (":" (NAME ":")? NAME ":")? "`" qualname "`"
+// An union of different types, joined either by "or" or "|".
+union: type (_OR type)+
 
 
-// An union of different types, joined either by "or" or "|"
-or_expression: type (("or" | "|") type)+
+// An expression where an object is subscribed with "A[v, ...]".
+subscription: qualname "[" type ("," type)* ("," ELLIPSES)? "]"
 
 
-// An expression where an object is subscribed with "A[v, ...]". We extend this
-// syntax with a natural language variants, e.g., `A of (v, ...)` and `A of {k : v}`.
-subscription_expression: qualname "[" type ("," type)* ("," ELLIPSES)? "]"
-    | qualname "of" type   // TODO allow plural somehow, e.g. "list of int(s)"?
-    | qualname "of" "(" type ("," type)* ("," ELLIPSES)? ")"
-    | qualname "of" "{" type ":" type "}"
-
-
-// An expression combining multiple literals inside curly braces `{l1, l2, ...}`
-literal_expression: "{" literal_item ("," literal_item)* "}"
+// A natural language version that combines one or multiple literals inside
+// curly braces `{l1, l2, ...}`
+natlang_literal: "{" literal_item ("," literal_item)* "}"
 
 
 // An single item in a literal expression (or `optional`). We must also allow
 // for qualified names, since a "class" can be used as a literal too.
-?literal_item: ELLIPSES
-    | STRING
-    | NUMBER
-    | qualname  // TODO should rst_role too? make combined `type qualname | rst_role`?
+?literal_item: ELLIPSES | STRING | NUMBER | qualname
+
+
+// A natural language form of the subscription expression for containers.
+// This variant explicitly doesn't allow nesting more complex types inside it
+// to maintain readability. However, unions with with simple qualnames are
+// allowed, e.g, `list of (int or float)`.
+natlang_container: qualname "of" qualname "(s)"?
+    | qualname "of" "(" union ")"
+    | _natlang_tuple
+    | _natlang_mapping
+
+
+// Special behavior for tuples [1].
+// [1] https://typing.python.org/en/latest/spec/tuples.html#tuple-type-form
+_natlang_tuple: qualname "of" "(" type "," ELLIPSES ")"
+    | qualname "of" "(" type ("," type)+ ")"
+
+
+// Natural language container variant for mappings.
+_natlang_mapping: qualname "of" "{" type ":" (type | union) "}"
 
 
 // A natural language alternative to describe arrays with a dtype and shape
-array_expression: array_name "of dtype" dtype ("and shape" shape)?
+natlang_array: array_name "of dtype" dtype ("and shape" shape)?
     | array_name "of shape" shape ("and dtype" dtype)?
     | shape array_name ("of" dtype)?
     | shape? array_name "of" dtype
     | shape dtype array_name
     | dtype array_name
 
-// Currently a bit of a hack. Since the `array_expression` is currently so
-// ambiguous, we want to make sure it only works for real arrays. For now, we
-// are using a hack here, that only allows specific names in `array_name`. In
-// the transformer we alias this to qualname.
+
+// Currently a bit of a hack. Since the `array_expression` is ambiguous, we
+// want to make sure it only works for real arrays. For now, we are using a
+// hack here, that only allows specific names in `array_name`. In the
+// transformer we alias this to qualname.
+//
 // TODO  figure out less hacky way & allow users to set other array names
 array_name: ARRAY_NAME
 ARRAY_NAME: "array" | "ndarray" | "array-like" | "array_like"
 
 // The dtype used in an array expression.
-?dtype: qualname
+?dtype: qualname | "(" union ")"
 
 // The shape used in an array expression. Possibly to liberal right now in
 // what it allows. Since there is currently no support to type the shape of
@@ -101,6 +118,10 @@ optional:  "optional" | "default" ("=" | ":")? literal_item
 // Extra meta information added after the docstring annotation.
 // Currently dropped during transformation.
 extra_info: /[^\r\n]+/
+
+
+// Operator used in unions.
+_OR: "or" | "|"
 
 
 // Allow Python's ellipses object

--- a/src/docstub/doctype.lark
+++ b/src/docstub/doctype.lark
@@ -3,13 +3,13 @@
 // Reading and introduction order of rules starts at the top of the tree.
 
 
-?start : annotation_with_meta
+?start: annotation_with_meta
 
 
 // The basic structure of a full docstring annotation as it comes after the
 // `name : `. It includes additional meta information that is optional and
 // currently ignored.
-annotation_with_meta : type ("," optional)? ("," extra_info)?
+annotation_with_meta: type ("," optional)? ("," extra_info)?
 
 
 // Just the docstring type annotation without meta information.
@@ -22,20 +22,20 @@ annotation_with_meta : type ("," optional)? ("," extra_info)?
 
 
 // Name with leading dot separated path
-qualname : (/~/ ".")? (NAME ".")* NAME
+qualname: (/~/ ".")? (NAME ".")* NAME
 
 
 // A qualname can be wrapped in a reStructuredText role, e.g, as used by Sphinx.
 // https://docutils.sourceforge.io/docs/ref/rst/roles.html
-rst_role : (":" (NAME ":")? NAME ":")? "`" qualname "`"
+rst_role: (":" (NAME ":")? NAME ":")? "`" qualname "`"
 
 
 // An union of different types, joined either by "or" or "|"
-or_expression : type (("or" | "|") type)+
+or_expression: type (("or" | "|") type)+
 
 
 // An expression where an object is subscribed with "A[v, ...]". We extend this
-// syntax with a natural language variant `A of (v, ...)` and `A of {k : v}`.
+// syntax with a natural language variants, e.g., `A of (v, ...)` and `A of {k : v}`.
 subscription_expression: qualname "[" type ("," type)* ("," ELLIPSES)? "]"
     | qualname "of" type   // TODO allow plural somehow, e.g. "list of int(s)"?
     | qualname "of" "(" type ("," type)* ("," ELLIPSES)? ")"
@@ -43,7 +43,7 @@ subscription_expression: qualname "[" type ("," type)* ("," ELLIPSES)? "]"
 
 
 // An expression combining multiple literals inside curly braces `{l1, l2, ...}`
-literal_expression : "{" literal_item ("," literal_item)* "}"
+literal_expression: "{" literal_item ("," literal_item)* "}"
 
 
 // An single item in a literal expression (or `optional`). We must also allow
@@ -67,11 +67,11 @@ array_expression: array_name "of dtype" dtype ("and shape" shape)?
 // are using a hack here, that only allows specific names in `array_name`. In
 // the transformer we alias this to qualname.
 // TODO  figure out less hacky way & allow users to set other array names
-array_name : ARRAY_NAME
-ARRAY_NAME : "array" | "ndarray" | "array-like" | "array_like"
+array_name: ARRAY_NAME
+ARRAY_NAME: "array" | "ndarray" | "array-like" | "array_like"
 
 // The dtype used in an array expression.
-?dtype : qualname
+?dtype: qualname
 
 // The shape used in an array expression. Possibly to liberal right now in
 // what it allows. Since there is currently no support to type the shape of
@@ -82,29 +82,29 @@ shape: "(" dim ",)"
 
 // Optional dimensions in a `shape` expression placed at the start,
 // e.g., `([3 ,] N)`.
-?leading_optional_dim : "[" dim ("," dim)* ",]"
+?leading_optional_dim: "[" dim ("," dim)* ",]"
 
 // Optional dimensions in a `shape` expression placed anywhere but the start,
 // e.g., `(A[, B], C[, D])`.
-?insert_optional_dim : "[," dim ("," dim)* "]"
+?insert_optional_dim: "[," dim ("," dim)* "]"
 
 // Dimension can be a number, ellipses ('...') or a simple name. A simple name
 // can be bound to a specific number, e.g. `N=3`.
-?dim : NUMBER | ELLIPSES | NAME ("=" NUMBER)?
+?dim: NUMBER | ELLIPSES | NAME ("=" NUMBER)?
 
 
 // Optional information about a parameter has a default value, added after the
 // docstring annotation. Currently dropped during transformation.
-optional :  "optional" | "default" ("=" | ":")? literal_item
+optional:  "optional" | "default" ("=" | ":")? literal_item
 
 
 // Extra meta information added after the docstring annotation.
 // Currently dropped during transformation.
-extra_info : /[^\r\n]+/
+extra_info: /[^\r\n]+/
 
 
 // Allow Python's ellipses object
-ELLIPSES : "..."
+ELLIPSES: "..."
 
 // A simple name. Can start with a number or character. Can be delimited by "_"
 // or "-" but not by ".".

--- a/tests/test_docstrings.py
+++ b/tests/test_docstrings.py
@@ -1,5 +1,6 @@
 from textwrap import dedent
 
+import lark
 import pytest
 
 from docstub._analysis import KnownImport
@@ -35,28 +36,72 @@ class Test_Annotation:
 
 
 class Test_DoctypeTransformer:
-    # fmt: off
     @pytest.mark.parametrize(
         ("doctype", "expected"),
         [
+            # Conventional
             ("list[float]", "list[float]"),
             ("dict[str, Union[int, str]]", "dict[str, Union[int, str]]"),
             ("tuple[int, ...]", "tuple[int, ...]"),
-
-            ("list of int", "list[int]"),
-            ("tuple of float", "tuple[float]"),
-            ("tuple of (float, ...)", "tuple[float, ...]"),
-
             ("Sequence[int | float]", "Sequence[int | float]"),
-
+            # Natural language variant with "of" and optional plural "(s)"
+            ("list of int", "list[int]"),
+            ("list of int(s)", "list[int]"),
+            # Natural tuple variant
+            ("tuple of (float, int, str)", "tuple[float, int, str]"),
+            ("tuple of (float, ...)", "tuple[float, ...]"),
+            # Natural dict variant
             ("dict of {str: int}", "dict[str, int]"),
+            ("dict of {str: int | float}", "dict[str, int | float]"),
+            ("dict of {str: int or float}", "dict[str, int | float]"),
+            ("dict[list of str]", "dict[list[str]]"),
         ],
     )
-    def test_container(self, doctype, expected):
+    def test_subscription(self, doctype, expected):
         transformer = DoctypeTransformer()
         annotation, _ = transformer.doctype_to_annotation(doctype)
         assert annotation.value == expected
-    # fmt: on
+
+    @pytest.mark.parametrize(
+        ("doctype", "expected"),
+        [
+            # Natural language variant with "of" and optional plural "(s)"
+            ("list of int", "list[int]"),
+            ("list of int(s)", "list[int]"),
+            ("list of (int or float)", "list[int | float]"),
+            # Natural tuple variant
+            ("tuple of (float, int, str)", "tuple[float, int, str]"),
+            ("tuple of (float, ...)", "tuple[float, ...]"),
+            # Natural dict variant
+            ("dict of {str: int}", "dict[str, int]"),
+            ("dict of {str: int | float}", "dict[str, int | float]"),
+            ("dict of {str: int or float}", "dict[str, int | float]"),
+            ("dict[list of str]", "dict[list[str]]"),
+        ],
+    )
+    def test_natlang_container(self, doctype, expected):
+        transformer = DoctypeTransformer()
+        annotation, _ = transformer.doctype_to_annotation(doctype)
+        assert annotation.value == expected
+
+    @pytest.mark.parametrize(
+        "doctype",
+        [
+            "list of (float)",
+            "list of (float,)",
+            "list of (, )",
+            "list of ...",
+            "list of (..., ...)",
+            "dict of {}",
+            "dict of {:}",
+            "dict of {a:}",
+            "dict of {:b}",
+        ],
+    )
+    def test_subscription_error(self, doctype):
+        transformer = DoctypeTransformer()
+        with pytest.raises(lark.exceptions.UnexpectedInput):
+            transformer.doctype_to_annotation(doctype)
 
     @pytest.mark.parametrize(
         ("doctype", "expected"),
@@ -64,6 +109,9 @@ class Test_DoctypeTransformer:
             ("{'a', 1, None, False}", "Literal['a', 1, None, False]"),
             ("dict[{'a', 'b'}, int]", "dict[Literal['a', 'b'], int]"),
             ("{SomeEnum.FIRST}", "Literal[SomeEnum_FIRST]"),
+            ("{`SomeEnum.FIRST`, 1}", "Literal[SomeEnum_FIRST, 1]"),
+            ("{:ref:`SomeEnum.FIRST`, 2}", "Literal[SomeEnum_FIRST, 2]"),
+            ("{:py:ref:`SomeEnum.FIRST`, 3}", "Literal[SomeEnum_FIRST, 3]"),
         ],
     )
     def test_literals(self, doctype, expected):
@@ -97,10 +145,12 @@ class Test_DoctypeTransformer:
             ("`Generator`", "Generator"),
             (":class:`Generator`", "Generator"),
             (":py:class:`Generator`", "Generator"),
+            (":py:class:`Generator`[int]", "Generator[int]"),
+            (":py:ref:`~.Foo`[int]", "_Foo[int]"),
             ("list[:py:class:`Generator`]", "list[Generator]"),
         ],
     )
-    def test_sphinx_ref(self, doctype, expected):
+    def test_rst_role(self, doctype, expected):
         transformer = DoctypeTransformer()
         annotation, _ = transformer.doctype_to_annotation(doctype)
         assert annotation.value == expected
@@ -120,7 +170,7 @@ class Test_DoctypeTransformer:
     @pytest.mark.parametrize("name", ["array", "ndarray", "array-like", "array_like"])
     @pytest.mark.parametrize("dtype", ["int", "np.int8"])
     @pytest.mark.parametrize("shape", ["(2, 3)", "(N, m)", "3D", "2-D", "(N, ...)"])
-    def test_shape_n_dtype(self, fmt, expected_fmt, name, dtype, shape):
+    def test_natlang_array(self, fmt, expected_fmt, name, dtype, shape):
 
         def escape(name: str) -> str:
             return name.replace("-", "_").replace(".", "_")

--- a/tests/test_docstrings.py
+++ b/tests/test_docstrings.py
@@ -87,6 +87,7 @@ class Test_DoctypeTransformer:
     @pytest.mark.parametrize(
         "doctype",
         [
+            "list of int (s)",
             "list of (float)",
             "list of (float,)",
             "list of (, )",

--- a/tests/test_docstrings.py
+++ b/tests/test_docstrings.py
@@ -107,6 +107,7 @@ class Test_DoctypeTransformer:
     @pytest.mark.parametrize(
         ("doctype", "expected"),
         [
+            ("{0}", "Literal[0]"),
             ("{'a', 1, None, False}", "Literal['a', 1, None, False]"),
             ("dict[{'a', 'b'}, int]", "dict[Literal['a', 'b'], int]"),
             ("{SomeEnum.FIRST}", "Literal[SomeEnum_FIRST]"),


### PR DESCRIPTION
Removes an implicit match for "" (nothing) because I left the first line after the ":" empty. Obviously not what is intended! So while it would be more readable to be able to wrap everything inside a rule with an indent, it doesn't seem to be supported currently [1].

Also, allow appending `(s)` to indicate plural in expressions like `list of int(s)`. A negative lookbehind regex disallows a space directly in front of `(s)`.

Other changes improve on naming, structure and tests.

[1] [www.github.com/lark-parser/lark/issues/155](http://www.github.com/lark-parser/lark/issues/155)