### PR TITLE
fix check for length 1 literal

### DIFF
--- a/src/docstub/_docstrings.py
+++ b/src/docstub/_docstrings.py
@@ -381,7 +381,7 @@ class DoctypeTransformer(lark.visitors.Transformer):
         out = ", ".join(tree.children)
         out = f"Literal[{out}]"
 
-        if len(tree.children):
+        if len(tree.children) == 1:
             logger.warning(
                 "natural language literal with one item `%s`, "
                 "consider using `%s` to improve readability",


### PR DESCRIPTION
closes #38.

I think I have added tests to check for logger messages being or not being there somewhere.
I could search for it if you want to explicitly test the warning.
