### PR TITLE
Refactor configuration fields

### DIFF
--- a/examples/docstub.toml
+++ b/examples/docstub.toml
@@ -1,20 +1,16 @@
 [tool.docstub]
 
-# TODO not implemented and used yet
-extend_grammar = """
-
-"""
-
-# Import information for type annotations, declared ahead of time.
+# Prefixes for external modules to match types in docstrings.
+# Docstub can't yet automatically discover where to import types from other
+# packages from. Instead, you can provide this information explicitly.
+# Any type in a docstring whose prefix matches the name given on the left side,
+# will be associated with the given "module" on the right side.
 #
-# Each item maps an annotation name on the left side to a dictionary on the
-# right side.
+# Examples:
+# np = "numpy"
+#     Will match `np.uint8` and `np.typing.NDarray` and use "import numpy as np".
 #
-# Import information can be declared with the following fields:
-#     from : Indicate that the DocType can be imported from this path.
-#     import : Import this object, defaults to the DocType.
-#     as : Use this alias for the imported object
-#     is_builtin : Indicate that this DocType doesn't need to be imported,
-#         defaults to "false"
-[tool.docstub.known_imports]
-configparser = {import = "configparser"}
+# plt = "matplotlib.pyplot
+#     Will match `plt.Figure` use `import matplotlib.pyplot as plt`.
+[tool.docstub.type_prefixes]
+configparser = "configparser"

--- a/examples/example_pkg/_basic.py
+++ b/examples/example_pkg/_basic.py
@@ -58,7 +58,7 @@ def func_use_from_elsewhere(a1, a2, a3, a4):
     ----------
     a1 : example_pkg.CustomException
     a2 : ExampleClass
-    a3 : example_pkg.CustomException.NestedClass
+    a3 : example_pkg._basic.ExampleClass.NestedClass
     a4 : ExampleClass.NestedClass
 
     Returns

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,10 +105,10 @@ testpaths = [
 [tool.coverage]
 run.source = ["docstub"]
 
-[tool.docstub.known_imports]
-cst = {import = "libcst", as="cst"}
-lark = {import = "lark"}
-numpydoc = {import = "numpydoc"}
+[tool.docstub.type_prefixes]
+cst = "libcst"
+lark = "lark"
+numpydoc = "numpydoc"
 
 
 [tool.mypy]

--- a/src/docstub/_docstrings.py
+++ b/src/docstub/_docstrings.py
@@ -11,6 +11,10 @@ import lark
 import lark.visitors
 import numpydoc.docscrape as npds
 
+# TODO Uncouple docstrings & analysis module
+#   It should be possible to transform docstrings without matching to valid
+#   types and imports. I think that could very well be done at a higher level,
+#   e.g. in the stubs module.
 from ._analysis import KnownImport, TypesDatabase
 from ._utils import DocstubError, ErrorReporter, accumulate_qualname, escape_qualname
 

--- a/src/docstub/_docstrings.py
+++ b/src/docstub/_docstrings.py
@@ -15,8 +15,8 @@ import numpydoc.docscrape as npds
 #   It should be possible to transform docstrings without matching to valid
 #   types and imports. I think that could very well be done at a higher level,
 #   e.g. in the stubs module.
-from ._analysis import KnownImport, TypesDatabase
-from ._utils import DocstubError, ErrorReporter, accumulate_qualname, escape_qualname
+from ._analysis import KnownImport, TypeMatcher
+from ._utils import DocstubError, ErrorReporter, escape_qualname
 
 logger = logging.getLogger(__name__)
 
@@ -175,8 +175,7 @@ class DoctypeTransformer(lark.visitors.Transformer):
 
     Attributes
     ----------
-    types_db : ~.TypesDatabase
-    replace_doctypes : dict[str, str]
+    matcher : ~.TypeMatcher
     stats : dict[str, Any]
     blacklisted_qualnames : ClassVar[frozenset[str]]
         All Python keywords [1]_ are blacklisted from use in qualnames except for ``True``
@@ -235,26 +234,18 @@ class DoctypeTransformer(lark.visitors.Transformer):
         }
     )
 
-    def __init__(self, *, types_db=None, replace_doctypes=None, **kwargs):
+    def __init__(self, *, matcher=None, **kwargs):
         """
         Parameters
         ----------
-        types_db : ~.TypesDatabase, optional
-            A static database of collected types usable as an annotation. If
-            not given, defaults to a database with common types from the
-            standard library (see :func:`~.common_known_imports`).
-        replace_doctypes : dict[str, str], optional
-            Replacements for human-friendly aliases.
+        matcher : ~.TypeMatcher, optional
         kwargs : dict[Any, Any], optional
             Keyword arguments passed to the init of the parent class.
         """
-        if replace_doctypes is None:
-            replace_doctypes = {}
-        if types_db is None:
-            types_db = TypesDatabase()
+        if matcher is None:
+            matcher = TypeMatcher()
 
-        self.types_db = types_db
-        self.replace_doctypes = replace_doctypes
+        self.matcher = matcher
 
         self._collected_imports = None
         self._unknown_qualnames = None
@@ -311,12 +302,6 @@ class DoctypeTransformer(lark.visitors.Transformer):
         """
         children = tree.children
         _qualname = ".".join(children)
-
-        for partial_qualname in accumulate_qualname(_qualname):
-            replacement = self.replace_doctypes.get(partial_qualname)
-            if replacement:
-                _qualname = _qualname.replace(partial_qualname, replacement)
-                break
 
         _qualname = self._match_import(_qualname, meta=tree.meta)
 
@@ -393,8 +378,8 @@ class DoctypeTransformer(lark.visitors.Transformer):
                 out,
             )
 
-        if self.types_db is not None:
-            _, known_import = self.types_db.query("Literal")
+        if self.matcher is not None:
+            _, known_import = self.matcher.match("Literal")
             if known_import:
                 self._collected_imports.add(known_import)
         return out
@@ -523,8 +508,8 @@ class DoctypeTransformer(lark.visitors.Transformer):
         matched_qualname : str
             Possibly modified or normalized qualname.
         """
-        if self.types_db is not None:
-            annotation_name, known_import = self.types_db.query(qualname)
+        if self.matcher is not None:
+            annotation_name, known_import = self.matcher.match(qualname)
         else:
             annotation_name = None
             known_import = None

--- a/src/docstub/default_config.toml
+++ b/src/docstub/default_config.toml
@@ -1,32 +1,43 @@
 [tool.docstub]
 
-# TODO not implemented and used yet
-extend_grammar = """
-
-"""
-
-# Import information for type annotations, declared ahead of time.
-#
-# Each item maps an annotation name on the left side to a dictionary on the
+# Types and their external modules to use in docstrings.
+# Docstub can't yet automatically discover where to import types from other
+# packages from. Instead, you can provide this information explicitly.
+# Any type on the left side will be associated with the given "module" on the
 # right side.
 #
-# Import information can be declared with the following fields:
-#     from : Indicate that the DocType can be imported from this path.
-#     import : Import this object, defaults to the DocType.
-#     as : Use this alias for the imported object
-#     is_builtin : Indicate that this DocType doesn't need to be imported,
-#         defaults to "false"
-[tool.docstub.known_imports]
-Path = { from = "pathlib" }
-Callable = { from = "collections.abc" }
-np = { import = "numpy", as = "np" }
-NDArray = { from = "numpy.typing" }
-ArrayLike = { from = "numpy.typing" }
+# Examples:
+# Path = "pathlib"
+#     Will allow using "Path" and use "from pathlib import Path".
+#
+# NDArray = "numpy.typing"
+#     Will allow "NDarray" and use "from numpy.typing import NDArray".
+[tool.docstub.types]
+Path = "pathlib"
+NDArray = "numpy.typing"
+ArrayLike = "numpy.typing"
 
-# Specify human-friendly aliases that can be used instead of Python-parsable
-# annotations.
-# TODO rename to qualname_alias or something
-[tool.docstub.replace_doctypes]
+
+# Prefixes for external modules to match types in docstrings.
+# Docstub can't yet automatically discover where to import types from other
+# packages from. Instead, you can provide this information explicitly.
+# Any type in a docstring whose prefix matches the name given on the left side,
+# will be associated with the given "module" on the right side.
+#
+# Examples:
+# np = "numpy"
+#     Will match `np.uint8` and `np.typing.NDarray` and use "import numpy as np".
+#
+# plt = "matplotlib.pyplot
+#     Will match `plt.Figure` use `import matplotlib.pyplot as plt`.
+[tool.docstub.type_prefixes]
+np = "numpy"
+numpy = "numpy"
+
+
+# Specify human-friendly aliases that can be used in docstrings to describe
+# valid Python types or annotations.
+[tool.docstub.type_aliases]
 iterable = "Iterable"
 callable = "Callable"
 function = "Callable"
@@ -34,14 +45,14 @@ func = "Callable"
 sequence = "Sequence"
 mapping = "Mapping"
 
-numpy = "np"
+# NumPy
 scalar = "np.ScalarType"
 integer = "np.integer"
 signedinteger = "np.signedinteger"
-byte ="np.byte"
-short = "np.short"
+#byte ="np.byte"
+#short = "np.short"
 intc = "np.intc"
-int_ = "np.int_"
+#int_ = "np.int_"
 longlong = "np.longlong"
 int8 = "np.int8"
 int16 = "np.int16"
@@ -76,13 +87,13 @@ complex64 = "np.complex64"
 complex128 = "np.complex128"
 complex192 = "np.complex192"
 complex256 = "np.complex256"
-bool_ = "np.bool_"
+#bool_ = "np.bool_"
 datetime64 = "np.datetime64"
 timedelta64 = "np.timedelta64"
-object_ = "np.object_"
+#object_ = "np.object_"
 #flexible = "np.flexible"
 #character = "np.character"
-bytes_ = "np.bytes_"
+#bytes_ = "np.bytes_"
 #str_ = "np.str_"
 #void = "np.void"
 ndarray = "NDArray"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,9 @@
+from docstub._config import Config
+
+
+class Test_Config:
+    def test_from_default(self):
+        config = Config.from_default()
+        assert len(config.types) > 0
+        assert len(config.type_prefixes) > 0
+        assert len(config.type_aliases) > 0


### PR DESCRIPTION
Hopefully, these config fields are somewhat easier to explain in #24. The previous fields were just doing too much. E.g. "known_imports" covered what is now split into "types" and "type_prefixes" use case.

In the process also simplify the architecture somewhat. It still doesn't feel completely clean but "baby steps".