### PR TITLE
Check `tests/` with basedpyright in CI in "standard" mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,3 +90,7 @@ jobs:
       - name: Check tests/ with mypy
         run: |
           python -m mypy tests/
+
+      - name: Check tests/ with basedpyright
+        run: |
+          basedpyright tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "docstub"
 authors = [
   {name = "Lars Grüter"},
 ]
-description = "Generate Python stub files (PYI) from docstrings"
+description = "Generate Python stub files from docstrings"
 readme = "README.md"
 license.file = "LICENSE"
 requires-python = ">=3.12"
@@ -46,6 +46,7 @@ test = [
   "pytest >=5.0.0",
   "pytest-cov >= 5.0.0",
   "mypy",
+  "basedpyright",
 ]
 
 [project.urls]
@@ -129,3 +130,8 @@ disable_error_code = ["var-annotated", "union-attr"]
 [[tool.mypy.overrides]]
 module = ["numpydoc.*"]
 ignore_missing_imports = true
+
+
+[tool.basedpyright]
+stubPath = "stubs/"
+typeCheckingMode = "standard"

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -148,6 +148,8 @@ class Test_TypeMatcher:
             assert expected_name is type_name
             assert expected_origin is type_origin
         else:
+            assert type_name is not None
+            assert type_origin is not None
             assert str(type_origin) == expected_origin
             assert type_name.startswith(type_origin.target)
             assert type_name == expected_name
@@ -174,6 +176,8 @@ class Test_TypeMatcher:
             assert expected_name is type_name
             assert expected_origin is type_origin
         else:
+            assert type_name is not None
+            assert type_origin is not None
             assert str(type_origin) == expected_origin
             assert type_name.startswith(type_origin.target)
             assert type_name == expected_name

--- a/tests/test_docstrings.py
+++ b/tests/test_docstrings.py
@@ -207,7 +207,7 @@ class Test_DoctypeTransformer:
         doctype = f"array of shape {shape}"
         transformer = DoctypeTransformer()
         with pytest.raises(lark.exceptions.UnexpectedInput):
-            transformer.doctype_to_annotation(doctype)
+            _ = transformer.doctype_to_annotation(doctype)
 
     def test_unknown_name(self):
         # Simple unknown name is aliased to typing.Any
@@ -302,6 +302,7 @@ class Test_DocstringAnnotations:
         ).format(*doctypes)
         transformer = DoctypeTransformer()
         annotations = DocstringAnnotations(docstring, transformer=transformer)
+        assert annotations.returns is not None
         assert annotations.returns.value == expected
 
     def test_yields(self, caplog):
@@ -315,6 +316,7 @@ class Test_DocstringAnnotations:
         )
         transformer = DoctypeTransformer()
         annotations = DocstringAnnotations(docstring, transformer=transformer)
+        assert annotations.returns is not None
         assert annotations.returns.value == "Generator[tuple[int, str]]"
         assert annotations.returns.imports == {
             KnownImport(import_path="collections.abc", import_name="Generator")
@@ -336,6 +338,7 @@ class Test_DocstringAnnotations:
         )
         transformer = DoctypeTransformer()
         annotations = DocstringAnnotations(docstring, transformer=transformer)
+        assert annotations.returns is not None
         assert (
             annotations.returns.value
             == "Generator[tuple[int, str], tuple[float, bytes]]"
@@ -364,6 +367,7 @@ class Test_DocstringAnnotations:
         )
         transformer = DoctypeTransformer()
         annotations = DocstringAnnotations(docstring, transformer=transformer)
+        assert annotations.returns is not None
         assert annotations.returns.value == (
             "Generator[tuple[int, str], tuple[float, bytes], bool]"
         )
@@ -386,6 +390,7 @@ class Test_DocstringAnnotations:
         )
         transformer = DoctypeTransformer()
         annotations = DocstringAnnotations(docstring, transformer=transformer)
+        assert annotations.returns is not None
         assert annotations.returns.value == ("Generator[tuple[int, str], None, bool]")
         assert annotations.returns.imports == {
             KnownImport(import_path="collections.abc", import_name="Generator")
@@ -416,6 +421,8 @@ class Test_DocstringAnnotations:
         )
         transformer = DoctypeTransformer()
         annotations = DocstringAnnotations(docstring, transformer=transformer)
+        assert annotations.returns is not None
+        assert annotations.returns is not None
         assert annotations.returns.value == "int"
 
     def test_args_kwargs(self):

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -52,6 +52,7 @@ class Test_get_docstring_node:
         assert isinstance(func_def, cst.FunctionDef)
         docstring_node = _get_docstring_node(func_def)
 
+        assert isinstance(docstring_node, cst.SimpleString)
         assert docstring_node.value == docstring
 
     def test_func_without_docstring(self):
@@ -196,7 +197,8 @@ class Test_Py2StubTransformer:
             src = MODULE_ATTRIBUTE_TEMPLATE.format(assign=assign, doctype="")
         elif scope == "class":
             src = CLASS_ATTRIBUTE_TEMPLATE.format(assign=assign, doctype="")
-        elif scope == "nested class":
+        else:
+            assert scope == "nested class"
             src = NESTED_CLASS_ATTRIBUTE_TEMPLATE.format(assign=assign, doctype="")
 
         transformer = Py2StubTransformer()
@@ -234,7 +236,8 @@ class Test_Py2StubTransformer:
             src = MODULE_ATTRIBUTE_TEMPLATE.format(assign=assign, doctype=doctype)
         elif scope == "class":
             src = CLASS_ATTRIBUTE_TEMPLATE.format(assign=assign, doctype=doctype)
-        elif scope == "nested class":
+        else:
+            assert scope == "nested class"
             src = NESTED_CLASS_ATTRIBUTE_TEMPLATE.format(assign=assign, doctype=doctype)
 
         transformer = Py2StubTransformer()


### PR DESCRIPTION
Use [basedpyright](https://docs.basedpyright.com/latest/) in addition to mypy to validate docstubs stubs on the test suite in `tests/`.

And fix reported errors in the process.
