### PR TITLE
Allow prefixing common known types with module name

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -100,7 +100,9 @@ There are several interesting things to note here:
 - Optional arguments that default to `None` are recognized and a `| None` is appended automatically if the type doesn't include it already.
   The `optional` or `default = ...` part don't influence the annotation.
 
-- Common container types from Python's standard library such as `Iterable` can be used and a necessary import will be added automatically.
+- Referencing the `float` and `Iterable` types worked out of the box.
+  All builtin types as well as types from the standard libraries `typing` and `collections.abc` module can be used.
+  Necessary imports will be added automatically to the stub file.
 
 
 ## Using types & nicknames

--- a/examples/example_pkg-stubs/_basic.pyi
+++ b/examples/example_pkg-stubs/_basic.pyi
@@ -32,7 +32,7 @@ def func_literals(
 def func_use_from_elsewhere(
     a1: CustomException,
     a2: ExampleClass,
-    a3: CustomException.NestedClass,
+    a3: ExampleClass.NestedClass,
     a4: ExampleClass.NestedClass,
 ) -> tuple[CustomException, ExampleClass.NestedClass]: ...
 

--- a/examples/example_pkg-stubs/_numpy.pyi
+++ b/examples/example_pkg-stubs/_numpy.pyi
@@ -1,10 +1,11 @@
 # File generated with docstub
 
+import numpy
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
 
 def func_object_with_numpy_objects(
-    a1: np.int8, a2: np.int16, a3: np.typing.DTypeLike, a4: np.typing.DTypeLike
+    a1: numpy.int8, a2: np.int16, a3: numpy.typing.DTypeLike, a4: np.typing.DTypeLike
 ) -> None: ...
 def func_ndarray(
     a1: NDArray, a2: np.NDArray, a3: NDArray[float], a4: NDArray[np.uint8] | None = ...

--- a/examples/example_pkg/_basic.py
+++ b/examples/example_pkg/_basic.py
@@ -33,7 +33,7 @@ def func_contains(a1, a2, a3, a4, a5, a6, a7):
     ----------
     a1 : list[float]
     a2 : dict[str, Union[int, str]]
-    a3 : Sequence[int | float]
+    a3 : collections.abc.Sequence[int | float]
     a4 : frozenset[bytes]
     a5 : tuple of int
     a6 : list of (int, str)

--- a/src/docstub/_cli.py
+++ b/src/docstub/_cli.py
@@ -11,7 +11,7 @@ from ._analysis import (
     KnownImport,
     TypeCollector,
     TypeMatcher,
-    common_known_imports,
+    common_known_types,
 )
 from ._cache import FileCache
 from ._config import Config
@@ -89,7 +89,7 @@ def _collect_types(root_path):
     -------
     types : dict[str, ~.KnownImport]
     """
-    types = common_known_imports()
+    types = common_known_types()
 
     collect_cached_types = FileCache(
         func=TypeCollector.collect,
@@ -213,7 +213,7 @@ def run(root_path, out_dir, config_paths, group_errors, allow_errors, verbose):
 
     config = _load_configuration(config_paths)
 
-    types = common_known_imports()
+    types = common_known_types()
     types |= _collect_types(root_path)
     types |= {
         type_name: KnownImport(import_path=module, import_name=type_name)

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -2,7 +2,11 @@ from textwrap import dedent
 
 import pytest
 
-from docstub._analysis import KnownImport, TypeCollector, TypeMatcher
+from docstub._analysis import (
+    KnownImport,
+    TypeCollector,
+    TypeMatcher,
+)
 
 
 class Test_KnownImport:
@@ -182,3 +186,20 @@ class Test_TypeMatcher:
             assert type_name.startswith(type_origin.target)
             assert type_name == expected_name
     # fmt: on
+
+    @pytest.mark.parametrize(
+        ("search_name", "import_path"),
+        [
+            ("Iterable", "collections.abc"),
+            ("collections.abc.Iterable", "collections.abc"),
+            ("Literal", "typing"),
+            ("typing.Literal", "typing"),
+        ],
+    )
+    def test_common_known_types(self, search_name, import_path):
+        matcher = TypeMatcher()
+        type_name, type_origin = matcher.match(search_name)
+
+        assert type_name == search_name.split(".")[-1]
+        assert type_origin is not None
+        assert type_origin.import_path == import_path


### PR DESCRIPTION


#### Release note

([instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes))

```release-note
Support referencing types from `collections.abc` and `typing` with their
their module name included. So `collections.abc.Iterable` should work now.
``` 