### PR TITLE
Fix broken diff check due to changed output behavior

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,10 @@ jobs:
 
       - name: Compare example stubs
         run: |
-          python -m docstub run -v --config=examples/docstub.toml examples/example_pkg
+          python -m docstub run -v \
+              --config=examples/docstub.toml \
+              --out-dir=examples/example_pkg-stubs \
+              examples/example_pkg
           git diff --exit-code examples/ && echo "Stubs for example_pkg did not change"
 
       - name: Generate stubs for docstub


### PR DESCRIPTION
After defaulting to inplace stub creation, I think this check no longer picked up differences. `git diff` seems to ignore untracked files. This should correct the location of the written stubs.