### PR TITLE
Use imports to collect (scoped) type information

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -111,8 +111,9 @@ To translate a type from a docstring into a valid type annotation, docstub needs
 Out of the box, docstub will know about builtin types such as `int` or `bool` that don't need an import, and types in `typing`, `collections.abc` from Python's standard library.
 It will source these from the Python environment it is installed in.
 In addition to that, docstub will collect all types in the package directory you are running it on.
+This also includes imported types, which you can then use within the scope of the module that imports them.
 
-However, if you want to use types from third-party libraries you can tell docstub about them in a configuration file.
+However, you can also tell docstub directly about external types in a configuration file.
 Docstub will look for a `pyproject.toml` or `docstub.toml` in the current working directory.
 Or, you can point docstub at TOML file(s) explicitly using the `--config` option.
 In these configuration file(s) you can declare external types directly with
@@ -134,8 +135,9 @@ ski = "skimage"
 
 which will enable any type that is prefixed with `ski.` or `sklearn.tree.`, e.g. `ski.transform.AffineTransform` or `sklearn.tree.DecisionTreeClassifier`.
 
-In both of these cases, docstub doesn't check that these types actually exist.
-Testing the generated stubs with a type checker is recommended.
+> [!IMPORTANT]
+> Docstub doesn't check that types actually exist or if a symbol is a valid type.
+> We always recommend validating the generated stubs with a full type checker!
 
 > [!TIP]
 > Docstub currently collects types statically.

--- a/examples/example_pkg-stubs/__init__.pyi
+++ b/examples/example_pkg-stubs/__init__.pyi
@@ -10,3 +10,6 @@ __all__ = [
 
 class CustomException(Exception):
     pass
+
+class AnotherType:
+    pass

--- a/examples/example_pkg-stubs/_basic.pyi
+++ b/examples/example_pkg-stubs/_basic.pyi
@@ -1,15 +1,16 @@
 # File generated with docstub
 
-import configparser
 import logging
 from collections.abc import Sequence
+from configparser import ConfigParser
+from configparser import ConfigParser as Cfg
 from typing import Any, Literal, Self, Union
 
 from _typeshed import Incomplete
 
-from . import CustomException
+from . import AnotherType, CustomException
 
-logger: Incomplete
+logger: logging.Logger
 
 __all__ = [
     "func_empty",
@@ -39,6 +40,7 @@ def func_use_from_elsewhere(
     a3: ExampleClass.NestedClass,
     a4: ExampleClass.NestedClass,
 ) -> tuple[CustomException, ExampleClass.NestedClass]: ...
+def func_use_from_import(a1: AnotherType, a2: Cfg) -> None: ...
 
 class ExampleClass:
 
@@ -58,6 +60,6 @@ class ExampleClass:
     @some_property.setter
     def some_property(self, value: str) -> None: ...
     @classmethod
-    def method_returning_cls(cls, config: configparser.ConfigParser) -> Self: ...
+    def method_returning_cls(cls, config: ConfigParser) -> Self: ...
     @classmethod
-    def method_returning_cls2(cls, config: configparser.ConfigParser) -> Self: ...
+    def method_returning_cls2(cls, config: ConfigParser) -> Self: ...

--- a/examples/example_pkg/__init__.py
+++ b/examples/example_pkg/__init__.py
@@ -11,3 +11,7 @@ __all__ = [
 
 class CustomException(Exception):
     pass
+
+
+class AnotherType:
+    pass

--- a/examples/example_pkg/_basic.py
+++ b/examples/example_pkg/_basic.py
@@ -1,11 +1,18 @@
 """Basic docstring examples.
 
 Docstrings, including module-level ones, are stripped.
+
+Attributes
+----------
+logger : logging.Logger
 """
 
 # Existing imports are preserved
 import logging
+from configparser import ConfigParser as Cfg  # noqa: F401
 from typing import Literal
+
+from . import AnotherType  # noqa: F401
 
 # Assign-statements are preserved
 logger = logging.getLogger(__name__)  # Inline comments are stripped
@@ -85,6 +92,16 @@ def func_use_from_elsewhere(a1, a2, a3, a4):
     -------
     r1 : ~.CustomException
     r2 : ~.NestedClass
+    """
+
+
+def func_use_from_import(a1, a2):
+    """Check using symbols made available in this module with from imports.
+
+    Parameters
+    ----------
+    a1 : AnotherType
+    a2 : Cfg
     """
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,8 +119,8 @@ run.source = ["docstub"]
 ".*maintenance.*" = "Maintenance"
 
 
-[tool.docstub.type_nicknames]
-Path = "pathlib.Path"
+[tool.docstub.types]
+Path = "pathlib"
 
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,14 +119,8 @@ run.source = ["docstub"]
 ".*maintenance.*" = "Maintenance"
 
 
-[tool.docstub.types]
-Path = "pathlib"
-
-[tool.docstub.type_prefixes]
-re = "re"
-cst = "libcst"
-lark = "lark"
-numpydoc = "numpydoc"
+[tool.docstub.type_nicknames]
+Path = "pathlib.Path"
 
 
 [tool.mypy]

--- a/src/docstub/_cli.py
+++ b/src/docstub/_cli.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import click
 
 from ._analysis import (
-    KnownImport,
+    PyImport,
     TypeCollector,
     TypeMatcher,
     common_known_types,
@@ -93,8 +93,8 @@ def _collect_type_info(root_path, *, ignore=()):
 
     Returns
     -------
-    types : dict[str, ~.KnownImport]
-    type_prefixes : dict[str, ~.KnownImport]
+    types : dict[str, PyImport]
+    type_prefixes : dict[str, PyImport]
     """
     types = common_known_types()
     type_prefixes = {}
@@ -237,15 +237,15 @@ def run(root_path, out_dir, config_paths, ignore, group_errors, allow_errors, ve
 
     types, type_prefixes = _collect_type_info(root_path, ignore=config.ignore_files)
     types |= {
-        type_name: KnownImport(import_path=module, import_name=type_name)
+        type_name: PyImport(from_=module, import_=type_name)
         for type_name, module in config.types.items()
     }
 
     type_prefixes |= {
         prefix: (
-            KnownImport(import_name=module, import_alias=prefix)
+            PyImport(import_=module, as_=prefix)
             if module != prefix
-            else KnownImport(import_name=prefix)
+            else PyImport(import_=prefix)
         )
         for prefix, module in config.type_prefixes.items()
     }

--- a/src/docstub/_cli.py
+++ b/src/docstub/_cli.py
@@ -236,11 +236,14 @@ def run(root_path, out_dir, config_paths, ignore, group_errors, allow_errors, ve
     config = config.merge(Config(ignore_files=list(ignore)))
 
     types, type_prefixes = _collect_type_info(root_path, ignore=config.ignore_files)
+
+    # Add declared types from configuration
     types |= {
         type_name: PyImport(from_=module, import_=type_name)
         for type_name, module in config.types.items()
     }
 
+    # Add declared type prefixes from configuration
     type_prefixes |= {
         prefix: (
             PyImport(import_=module, as_=prefix)

--- a/src/docstub/_docstrings.py
+++ b/src/docstub/_docstrings.py
@@ -395,7 +395,7 @@ class DoctypeTransformer(lark.visitors.Transformer):
 
         if self.matcher is not None:
             _, py_import = self.matcher.match("Literal")
-            if py_import:
+            if py_import.has_import:
                 self._collected_imports.add(py_import)
         return out
 

--- a/src/docstub/_docstrings.py
+++ b/src/docstub/_docstrings.py
@@ -555,11 +555,11 @@ def _uncombine_numpydoc_params(params):
 
     Parameters
     ----------
-    params : list[numpydoc.docsrape.Parameter]
+    params : list[npds.Parameter]
 
     Yields
     ------
-    param : numpydoc.docscrape.Parameter
+    param : npds.Parameter
     """
     for param in params:
         if "," in param.name:
@@ -791,11 +791,11 @@ class DocstringAnnotations:
 
         Parameters
         ----------
-        param : numpydoc.docscrape.Parameter
+        param : npds.Parameter
 
         Returns
         -------
-        param : numpydoc.docscrape.Parameter
+        param : npds.Parameter
         """
         if ":" in param.name and param.type == "":
             msg = "Possibly missing whitespace between parameter and colon in docstring"

--- a/src/docstub/_stubs.py
+++ b/src/docstub/_stubs.py
@@ -14,7 +14,7 @@ from typing import ClassVar
 import libcst as cst
 import libcst.matchers as cstm
 
-from ._analysis import KnownImport
+from ._analysis import PyImport
 from ._docstrings import DocstringAnnotations, DoctypeTransformer
 from ._utils import ErrorReporter, module_name_from_path
 
@@ -571,7 +571,7 @@ class Py2StubTransformer(cst.CSTTransformer):
         # Potentially use "Incomplete" except for first param in (class)methods
         elif not is_self_or_cls and updated_node.annotation is None:
             node_changes["annotation"] = self._Annotation_Incomplete
-            import_ = KnownImport.typeshed_Incomplete()
+            import_ = PyImport.typeshed_Incomplete()
             self._required_imports.add(import_)
 
         if node_changes:
@@ -756,7 +756,7 @@ class Py2StubTransformer(cst.CSTTransformer):
         if self.current_source:
             current_module = module_name_from_path(self.current_source)
             required_imports = [
-                imp for imp in required_imports if imp.import_path != current_module
+                imp for imp in required_imports if imp.from_ != current_module
             ]
         import_nodes = self._parse_imports(
             required_imports, current_module=current_module
@@ -818,7 +818,7 @@ class Py2StubTransformer(cst.CSTTransformer):
 
         Parameters
         ----------
-        imports : set[~.KnownImport]
+        imports : set[PyImport]
         current_module : str, optional
 
         Returns
@@ -912,7 +912,7 @@ class Py2StubTransformer(cst.CSTTransformer):
             self._required_imports |= pytype.imports
         else:
             annotation = self._Annotation_Incomplete
-            self._required_imports.add(KnownImport.typeshed_Incomplete())
+            self._required_imports.add(PyImport.typeshed_Incomplete())
 
         semicolon = (
             cst.Semicolon(whitespace_after=cst.SimpleWhitespace(" "))

--- a/src/docstub/_stubs.py
+++ b/src/docstub/_stubs.py
@@ -318,7 +318,7 @@ class Py2StubTransformer(cst.CSTTransformer):
         # TODO pass current_source directly when using the transformer / matcher
         #   instead of assigning it here!
         if self.transformer is not None and self.transformer.matcher is not None:
-            self.transformer.matcher.current_module = value
+            self.transformer.matcher.current_file = value
 
     @property
     def is_inside_function_def(self):

--- a/src/docstub/_utils.py
+++ b/src/docstub/_utils.py
@@ -65,7 +65,7 @@ def escape_qualname(name):
     return qualname
 
 
-@lru_cache(maxsize=10)
+@lru_cache(maxsize=100)
 def module_name_from_path(path):
     """Find the full name of a module within its package from its file path.
 


### PR DESCRIPTION
Closes #20.

Adds support for collecting additional type information from existing imports in the parsed package. Also does quite a bit of internal refactoring and maintenance.

E.g. with this
```python
import dogs
from calendar import January as Jan, Day

def last_day(m, d):
    """
    Parameters
    ----------
    m : Jan
    d : dogs.Bernese

    Returns
    -------
    day : Day
    """
```
will work out of the box. `Jan` or `Day` will be picked up as implicitly available symbols in the given module. `dogs` will be collected as an import prefix in the module. They won't be available in other modules that don't feature these import statements.

We could also make these available to be used in other modules but for now I think this more conservative approach should be a good trade-off. It should save users from having to specify a large number of types manually. And weird import choices or naming conflicts are guarded by the scoping.

However, `calendar.January` will be collected as a global type and can be used in other modules.

This makes it more apparent that a full reference on docstubs type inference would be good to have in the documentation.



## Release note

```release-note
Use import statements in the parsed package to collect additional type
information. This makes imported types available in the same module
scope to be used in docstrings. Some of the imports can be used package
wide even if not imported there. E.g. `from pathlib import Path` will
allow using "Path" inside the modules scope. Outside of that module, 
you must use the full `pathlib.Path` to reference that type.
{label="enhancement"}
```

```release-note
Type nicknames specified in the configuration are now resolved recursively.
That means one nickname can point to another nickname.
{label="enhancement"}
```