### PR TITLE
Idea: Collect types into a tree data structure

### DIFF
--- a/src/docstub/_docstrings.py
+++ b/src/docstub/_docstrings.py
@@ -524,13 +524,14 @@ class DoctypeTransformer(lark.visitors.Transformer):
             Possibly modified or normalized qualname.
         """
         if self.matcher is not None:
-            annotation_name, known_import = self.matcher.match(qualname)
+            pynode = self.matcher.match(qualname)
+            annotation_name = pynode.fullname
         else:
             annotation_name = None
-            known_import = None
+            pynode = None
 
-        if known_import and known_import.has_import:
-            self._collected_imports.add(known_import)
+        if pynode and pynode.import_statement:
+            self._collected_imports.add(pynode.import_statement)
 
         if annotation_name:
             matched_qualname = annotation_name

--- a/src/docstub/_utils.py
+++ b/src/docstub/_utils.py
@@ -106,7 +106,7 @@ def module_name_from_path(path):
     return name
 
 
-def pyfile_checksum(path):
+def pyfile_checksum(path, salt=""):
     """Compute a unique key for a Python file.
 
     The key takes into account the given `path`, the relative position if the
@@ -124,7 +124,7 @@ def pyfile_checksum(path):
     absolute_path = str(path.resolve()).encode()
     with open(path, "rb") as fp:
         content = fp.read()
-    key = crc32(content + module_name + absolute_path)
+    key = crc32(content + module_name + absolute_path + salt.encode())
     return key
 
 


### PR DESCRIPTION
This approach would likely preserve more information and would make name matching a lot more efficient. Long-term it might even help with collecting from the typeshed.

The current implementation makes it hard to add features like matching types that were imported into the local namespace where a docstring is evaluated.