### PR TITLE
Improve handling of inline annotations without conflicts

### DIFF
--- a/src/docstub/_docstrings.py
+++ b/src/docstub/_docstrings.py
@@ -677,30 +677,11 @@ class DocstringAnnotations:
         -------
         attributes : dict[str, Annotation]
             A dictionary mapping attribute names to their annotations.
-            Attributes without annotations fall back to :class:`_typeshed.Incomplete`.
+            Attributes without annotations fall back to
+            :class:`FallbackAnnotation` which corresponds to
+            :class:`_typeshed.Incomplete`.
         """
-        annotations = {}
-        for attribute in self.np_docstring["Attributes"]:
-            self._handle_missing_whitespace(attribute)
-            if not attribute.type:
-                continue
-
-            ds_line = 0
-            for i, line in enumerate(self.docstring.split("\n")):
-                if attribute.name in line and attribute.type in line:
-                    ds_line = i
-                    break
-
-            if attribute.name in annotations:
-                self.reporter.message(
-                    "duplicate attribute name in docstring",
-                    details=self.reporter.underline(attribute.name),
-                )
-                continue
-
-            annotation = self._doctype_to_annotation(attribute.type, ds_line=ds_line)
-            annotations[attribute.name.strip()] = annotation
-
+        annotations = self._section_annotations("Attributes")
         return annotations
 
     @cached_property
@@ -711,7 +692,9 @@ class DocstringAnnotations:
         -------
         parameters : dict[str, Annotation]
             A dictionary mapping parameters names to their annotations.
-            Parameters without annotations fall back to :class:`_typeshed.Incomplete`.
+            Parameters without annotations fall back to
+            :class:`FallbackAnnotation` which corresponds to
+            :class:`_typeshed.Incomplete`.
         """
         param_section = self._section_annotations("Parameters")
         other_section = self._section_annotations("Other Parameters")

--- a/src/docstub/_stubs.py
+++ b/src/docstub/_stubs.py
@@ -15,7 +15,7 @@ import libcst as cst
 import libcst.matchers as cstm
 
 from ._analysis import PyImport
-from ._docstrings import DocstringAnnotations, DoctypeTransformer
+from ._docstrings import DocstringAnnotations, DoctypeTransformer, FallbackAnnotation
 from ._utils import ErrorReporter, module_name_from_path
 
 logger = logging.getLogger(__name__)
@@ -701,7 +701,7 @@ class Py2StubTransformer(cst.CSTTransformer):
                     updated_node.annotation, annotation=expr
                 )
 
-            else:
+            elif pytype != FallbackAnnotation:
                 # Notify about ignored docstring annotation
                 # TODO: either remove message or print only in verbose mode
                 position = self.get_metadata(


### PR DESCRIPTION
Uses `_section_annotations` to avoid duplicating code paths and logic, and makes sure that no note or warning is raised for inline annotations if there is no conflict with a doctype. Also improves the test suite around this.

```release-note
Make sure that no warning is raised for inline annotations, if there is no
conflicting annotation in a docstring. Otherwise, the inlined annotation 
takes precedence and a warning is printed.
{label='Bug fix'}
```