### PR TITLE
Make ignoring relative paths possible

### DIFF
--- a/src/docstub/_path_utils.py
+++ b/src/docstub/_path_utils.py
@@ -212,7 +212,8 @@ def _walk_source_package(path, *, ignore_regex):
     source_path : Path
         Either a Python file or a stub file that takes precedence.
     """
-    if ignore_regex and ignore_regex.match(str(path)):
+    # Make sure
+    if ignore_regex and ignore_regex.match(str(path.resolve())):
         logger.info("ignoring %s", path)
         return
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+import os
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def tmp_path_cwd(tmp_path):
+    """Fixture: Create temporary directory and use it as working directory.
+
+    .. warning::
+        Not written with parallelization in mind!
+    """
+    previous_cwd = Path.cwd()
+    os.chdir(tmp_path)
+    try:
+        yield tmp_path
+    except:
+        os.chdir(previous_cwd)
+        raise

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,6 @@
 """Test command line interface."""
 
 import logging
-import os
 from pathlib import Path
 
 import pytest
@@ -11,22 +10,6 @@ from docstub import _cli
 from docstub._cache import create_cache
 
 PROJECT_ROOT = Path(__file__).parent.parent
-
-
-@pytest.fixture
-def tmp_path_cwd(tmp_path):
-    """Fixture: Create temporary directory and use it as working directory.
-
-    .. warning::
-        Not written with parallelization in mind!
-    """
-    previous_cwd = Path.cwd()
-    os.chdir(tmp_path)
-    try:
-        yield tmp_path
-    except:
-        os.chdir(previous_cwd)
-        raise
 
 
 class Test_run:

--- a/tests/test_path_utils.py
+++ b/tests/test_path_utils.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from docstub._path_utils import STUB_HEADER_COMMENT, walk_source_package
@@ -122,3 +124,18 @@ class Test_walk_source_package:
 
         paths = sorted(walk_source_package(tmp_path, ignore=["**/*init*"]))
         assert paths == [stub_in_sub_package]
+
+    def test_ignore_relative_path(self, tmp_path_cwd):
+        init = tmp_path_cwd / "__init__.py"
+        init.touch()
+        tests_dir = tmp_path_cwd / "tests"
+        tests_dir.mkdir()
+        sub_init = tests_dir / "__init__.py"
+        sub_init.touch()
+
+        relative_cwd = Path()
+
+        paths = sorted(walk_source_package(relative_cwd))
+        assert [p.resolve() for p in paths] == [init, sub_init]
+        paths = sorted(walk_source_package(relative_cwd, ignore=["**/tests"]))
+        assert [p.resolve() for p in paths] == [init]


### PR DESCRIPTION
The glob patterns are internally translated to regex' that expect an absolute path. So if docstub was invoked with a relative path, they would never match.

## Release note

For maintainers and optionally contributors, please refer to [changelist's README](https://github.com/scientific-python/changelist) on how to document this PR for the release notes.

```release-note
Ensure glob patterns to ignore files work with relative paths. Previously, 
if docstub was invoked on a relative path, no files would be ignored.
```
