### PR TITLE
Add 14 days cooldown period to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "quarterly"
+    cooldown:
+      default-days: 14
     labels:
       - "devops"
       - "bot"


### PR DESCRIPTION
This makes dependabot only consider new releases that are older than 14 days. Effectively, this gives the community a chance to catch security issues.

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Use `pre-commit` to check and format code.
-->


## Release note

For maintainers and optionally contributors, please refer to [changelist's README](https://github.com/scientific-python/changelist) on how to document this PR for the release notes.

```release-note
...
```
