### PR TITLE
Include the `types` module in `common_known_types`

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -78,7 +78,7 @@ There are several interesting things to note here:
   The `optional` or `default = ...` part don't influence the annotation.
 
 - Referencing the `float` and `Iterable` worked out of the box.
-  All [built-in types](https://docs.python.org/3/library/stdtypes.html#built-in-types) as well as types from the standard library's `typing` and `collections.abc` module can be used like this.
+  All [built-in types](https://docs.python.org/3/library/stdtypes.html#built-in-types) as well as types from the standard library's `typing`, `types` and `collections.abc` module can be used like this.
   Necessary imports will be added automatically to the stub file.
 
 

--- a/src/docstub/_analysis.py
+++ b/src/docstub/_analysis.py
@@ -274,6 +274,7 @@ def common_known_types():
     types |= _runtime_types_in_module("typing")
     # Overrides containers from typing
     types |= _runtime_types_in_module("collections.abc")
+    types |= _runtime_types_in_module("types")
     return types
 
 

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -256,6 +256,8 @@ class Test_TypeMatcher:
             ("collections.abc.Iterable", "collections.abc"),
             ("Literal", "typing"),
             ("typing.Literal", "typing"),
+            ("NoneType", "types"),
+            ("SimpleNamespace", "types"),
         ],
     )
     def test_common_known_types(self, search_name, import_path):


### PR DESCRIPTION
Python's [`types`](https://docs.python.org/3/library/types.html) contains obviously useful types. 


## Release note

For maintainers and optionally contributors, please refer to [changelist's README](https://github.com/scientific-python/changelist) on how to document this PR for the release notes.

```release-note
Support using types from the standard library module `types` directly
without requiring configuration or imports for them.
```
